### PR TITLE
change hyperlink of igodlab -> /contetnt/

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -16,7 +16,7 @@ const config: QuartzConfig = {
       provider: "plausible",
     },
     locale: "en-US",
-    baseUrl: "igodlab.com",
+    baseUrl: "/content/",
     ignorePatterns: [
       "private", 
       "templates", 


### PR DESCRIPTION
igodlab hyperlink led to igodla.com, but seems that it is better practice to link it to within the site project