### PR TITLE
Alpha.bib

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -1,4 +1,12 @@
-// Ref:
+// 02-probability->2.7.1.2
+@article{minka2005divergence,
+  title={Divergence measures and message passing},
+  author={Minka, Tom},
+  year={2005},
+  publisher={Technical report, Microsoft Research},
+  url={https://miat.inrae.fr/AIGM/biblios/TR-2005-173.pdf}
+}
+
 // 2-Probability->2.6.3.2
 @article{halevy2009unreasonable,
   title={The unreasonable effectiveness of data},
@@ -12,7 +20,6 @@
   url={https://research.google.com/pubs/archive/35179.pdf}
 }
 
-// Ref:
 // 2-Probability->2.7.3.3
 @misc{chwialkowski2015fasttwosampletestinganalytic,
       title={Fast Two-Sample Testing with Analytic Representations of Probability Measures}, 
@@ -66,7 +73,8 @@
   title={An introduction to the bootstrap},
   author={Efron, Bradley and Tibshirani, Robert J},
   year={1994},
-  publisher={Chapman and Hall/CRC}
+  publisher={Chapman and Hall/CRC},
+  doi={https://doi.org/10.1201/9780429246593}
 }
 
 // test1

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -68,3 +68,30 @@
   year={1994},
   publisher={Chapman and Hall/CRC}
 }
+
+// test1
+@article{zhao2019sensitivity,
+  title={Sensitivity analysis for inverse probability weighting estimators via the percentile bootstrap},
+  author={Zhao, Qingyuan and Small, Dylan S and Bhattacharya, Bhaswar B},
+  journal={Journal of the Royal Statistical Society Series B: Statistical Methodology},
+  volume={81},
+  number={4},
+  pages={735--761},
+  year={2019},
+  publisher={Oxford University Press},
+  doi = {https://doi.org/10.1111/rssb.12327},
+  url = {https://rss.onlinelibrary.wiley.com/doi/abs/10.1111/rssb.12327},
+  eprint = {https://rss.onlinelibrary.wiley.com/doi/pdf/10.1111/rssb.12327},
+}
+
+// test2
+@article{zhang1998characterization,
+  title={On characterization of entropy function via information inequalities},
+  author={Zhang, Zhen and Yeung, Raymond W},
+  journal={IEEE transactions on information theory},
+  volume={44},
+  number={4},
+  pages={1440--1452},
+  year={1998},
+  publisher={IEEE}
+}

--- a/content/learning/probml/02-probability.md
+++ b/content/learning/probml/02-probability.md
@@ -138,7 +138,7 @@ balance equations wrt distribution $\pi$, then $\pi$ is a stationary distributio
 - (eq.2.888) uses the form $f(r)=r\log r$: $D_{\mathbb{KL}}(p ||q) = \int p(\boldsymbol{x}) \log{\frac{p(\boldsymbol{x})}{q(\boldsymbol{x})}} dx$
 
 #### 2.7.1.2 Alpha divergence
-- (eq.2.290)
+- If $f(x)=\frac{4}{a-\alpha^2}\left(1-x^{\frac{1+\alpha}{2}}\right)$ the $f$-divergence becomes the **alpha divergence** and using Minka's parameterization [@minka2005divergence] and $\alpha\neq\pm 1$ we get: $$D_\alpha^M=\frac{1}{\alpha(1-\alpha)}\left(1-\int p(\boldsymbol{x})^\alpha q(\boldsymbol{x})^{1-\alpha}d\boldsymbol{x}\right)$$
 
 #### 2.7.1.3 Hellinger divergence
 - (eq.2.291): $D_{H}^2 (p || q) = 1 - \int \sqrt{p(\boldsymbol{x})^{1/2} - q(\boldsymbol{x})^{1/2}}d\boldsymbol{x}$

--- a/content/learning/probml/02-probability.md
+++ b/content/learning/probml/02-probability.md
@@ -183,6 +183,8 @@ $D_{\mathcal{F}}(P, Q) \triangleq \sup _{f \in \mathcal{F}}\left|\mathbb{E}_{p(\
 - Moreover, the MMD is differentiable wrt the kernel parameters, so we can choose the optimal $\boldsymbol{\sigma}^2$ so as to maximize the power of the test
     - [@sutherland2021generativemodelsmodelcriticism]
     - bayesian version of the above [@flaxman2016bayesianlearningkernelembeddings]
+    - test citation [@zhao2019sensitivity]
+    - test2 [@zhang1998characterization]
     
     
 ### 2.7.4 Total variation distance (TV)

--- a/content/learning/probml/02-probability.md
+++ b/content/learning/probml/02-probability.md
@@ -183,7 +183,7 @@ $D_{\mathcal{F}}(P, Q) \triangleq \sup _{f \in \mathcal{F}}\left|\mathbb{E}_{p(\
 - Moreover, the MMD is differentiable wrt the kernel parameters, so we can choose the optimal $\boldsymbol{\sigma}^2$ so as to maximize the power of the test
     - [@sutherland2021generativemodelsmodelcriticism]
     - bayesian version of the above [@flaxman2016bayesianlearningkernelembeddings]
-    - test citation [@zhao2019sensitivity]
+    - test citation [@zhao2019sensitivity; @zhang1998characterization]
     - test2 [@zhang1998characterization]
     
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "4.5.1",
       "license": "MIT",
       "dependencies": {
+        "@citation-js/core": "^0.7.9",
+        "@citation-js/plugin-bibtex": "^0.7.9",
+        "@citation-js/plugin-csl": "^0.7.9",
         "@clack/prompts": "^0.11.0",
         "@floating-ui/dom": "^1.7.3",
         "@myriaddreamin/rehype-typst": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "quartz": "./quartz/bootstrap-cli.mjs"
   },
   "dependencies": {
+    "@citation-js/core": "^0.7.9",
+    "@citation-js/plugin-bibtex": "^0.7.9",
+    "@citation-js/plugin-csl": "^0.7.9",
     "@clack/prompts": "^0.11.0",
     "@floating-ui/dom": "^1.7.3",
     "@myriaddreamin/rehype-typst": "^0.6.0",

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -83,7 +83,8 @@ const config: QuartzConfig = {
       Plugin.Latex({ renderEngine: "katex" }),
       Plugin.Pseudocode(),
       // HACK: enable nice bibtex-style citations (and hoover over papers)
-      Plugin.Citations()
+      // Plugin.Citations()
+      Plugin.setupAlphaCitations()
     ],
     filters: [Plugin.RemoveDrafts()],
     emitters: [

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -84,7 +84,11 @@ const config: QuartzConfig = {
       Plugin.Pseudocode(),
       // HACK: enable nice bibtex-style citations (and hoover over papers)
       // Plugin.Citations()
-      Plugin.AlphaCitations()
+      Plugin.AlphaCitation({
+        bibliography: "bibliography.bib", // Use ./ for project root
+        linkCitations: true,
+        suppressBibliography: false,
+      }),    
     ],
     filters: [Plugin.RemoveDrafts()],
     emitters: [

--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -84,7 +84,7 @@ const config: QuartzConfig = {
       Plugin.Pseudocode(),
       // HACK: enable nice bibtex-style citations (and hoover over papers)
       // Plugin.Citations()
-      Plugin.setupAlphaCitations()
+      Plugin.AlphaCitations()
     ],
     filters: [Plugin.RemoveDrafts()],
     emitters: [

--- a/quartz/plugins/transformers/alpha-citations.ts
+++ b/quartz/plugins/transformers/alpha-citations.ts
@@ -110,17 +110,21 @@ class AlphaLabelGenerator {
     if (numAuthors === 0) return "UNK"
     
     if (numAuthors === 1) {
-      return this.extractSurname(authors[0]).substring(0, 3).toUpperCase()
+      // Single author: [Knu79] - first letter caps, rest lowercase
+      const surname = this.extractSurname(authors[0])
+      return surname.charAt(0).toUpperCase() + surname.substring(1, 3).toLowerCase()
     }
     
     if (numAuthors >= 2 && numAuthors <= 4) {
+      // 2-4 authors: [FSJC16] - all caps first letters
       return authors.map(name => 
         this.extractSurname(name).charAt(0).toUpperCase()
       ).join('')
     }
     
-    // 5+ authors
-    return this.extractSurname(authors[0]).substring(0, 3).toUpperCase() + '+'
+    // 5+ authors: [Sut+17] - first letter caps, rest lowercase
+    const surname = this.extractSurname(authors[0])
+    return surname.charAt(0).toUpperCase() + surname.substring(1, 3).toLowerCase() + '+'
   }
 
   private extractSurname(fullName: string): string {

--- a/quartz/plugins/transformers/alpha-citations.ts
+++ b/quartz/plugins/transformers/alpha-citations.ts
@@ -1,0 +1,417 @@
+import Cite from '@citation-js/core'
+import '@citation-js/plugin-bibtex'
+
+// If you need to register the plugin explicitly:
+// plugins.input.add('@bibtex/text', ...)
+
+interface BibEntry {
+  id: string;
+  type: string;
+  author?: Array<{given: string, family: string, literal?: string}>;
+  editor?: Array<{given: string, family: string, literal?: string}>;
+  title?: string;
+  'container-title'?: string; // journal, booktitle
+  volume?: string | number;
+  issue?: string | number; // number field in BibTeX
+  page?: string;
+  'page-first'?: string;
+  issued?: {['date-parts']: number[][]}; // year, month
+  publisher?: string;
+  'publisher-place'?: string; // address
+  note?: string;
+  keyword?: string; // key field
+  [key: string]: any; // for additional fields
+}
+
+class AlphaStyleGenerator {
+  private etAlCharUsed = false;
+  
+  constructor() {
+    // Initialize citation-js if needed
+  }
+
+  // Parse .bib file using citation-js
+  async parseBibFile(bibContent: string): Promise<BibEntry[]> {
+    try {
+      const cite = new Cite(bibContent, { forceType: '@bibtex/text' });
+      const entries = cite.data as BibEntry[];
+      
+      console.log('Parsed entries:', entries.length);
+      console.log('Sample entry:', entries[0]); // Debug: see the structure
+      
+      return entries;
+    } catch (error) {
+      console.error('Error parsing BibTeX file:', error);
+      throw error;
+    }
+  }
+
+  // Alternative: load from file path (Node.js)
+  async parseBibFromFile(filePath: string): Promise<BibEntry[]> {
+    const fs = await import('fs/promises');
+    const bibContent = await fs.readFile(filePath, 'utf-8');
+    return this.parseBibFile(bibContent);
+  }
+
+  // Generate alpha-style label (e.g., "Knu79")
+  generateAlphaLabel(entry: BibEntry): string {
+    let authorPart = "";
+    
+    // Handle different author/editor scenarios
+    if (entry.author && entry.author.length > 0) {
+      authorPart = this.formatLabNames(entry.author);
+    } else if (entry.editor && entry.editor.length > 0) {
+      authorPart = this.formatLabNames(entry.editor);
+    } else if (entry.keyword) {
+      // Use 'key' field if available
+      authorPart = entry.keyword.substring(0, 3).toUpperCase();
+    } else {
+      // Fallback to cite key
+      authorPart = entry.id.substring(0, 3).toUpperCase();
+    }
+
+    // Extract year (last 2 digits)
+    let yearPart = "";
+    if (entry.issued && entry.issued['date-parts'] && entry.issued['date-parts'][0]) {
+      const year = entry.issued['date-parts'][0][0];
+      yearPart = year.toString().slice(-2);
+    }
+
+    return authorPart + yearPart;
+  }
+
+  // Format author names for label generation
+  private formatLabNames(authors: Array<{given: string, family: string, literal?: string}>): string {
+    const numAuthors = authors.length;
+    
+    if (numAuthors === 1) {
+      const surname = authors[0].family || authors[0].literal || "";
+      return surname.length >= 3 ? surname.substring(0, 3).toUpperCase() : surname.toUpperCase();
+    }
+    
+    if (numAuthors <= 3) {
+      // Use first letter of each surname
+      return authors
+        .map(author => (author.family || author.literal || "").charAt(0).toUpperCase())
+        .join("");
+    }
+    
+    if (numAuthors === 4) {
+      // All four first letters
+      return authors
+        .map(author => (author.family || author.literal || "").charAt(0).toUpperCase())
+        .join("");
+    }
+    
+    // More than 4 authors: first 3 + "+"
+    const first3 = authors.slice(0, 3)
+      .map(author => (author.family || author.literal || "").charAt(0).toUpperCase())
+      .join("");
+    
+    this.etAlCharUsed = true;
+    return first3 + "+";
+  }
+
+  // Format author names for bibliography
+  formatAuthors(authors: Array<{given: string, family: string, literal?: string}>): string {
+    if (!authors || authors.length === 0) return "";
+    
+    const formatName = (author: {given: string, family: string, literal?: string}) => {
+      if (author.literal) return author.literal;
+      const given = author.given || "";
+      const family = author.family || "";
+      return given ? `${given} ${family}` : family;
+    };
+
+    if (authors.length === 1) {
+      return formatName(authors[0]);
+    } else if (authors.length === 2) {
+      return `${formatName(authors[0])} and ${formatName(authors[1])}`;
+    } else {
+      const allButLast = authors.slice(0, -1).map(formatName).join(", ");
+      return `${allButLast}, and ${formatName(authors[authors.length - 1])}`;
+    }
+  }
+
+  // Format title with proper capitalization
+  formatTitle(title: string): string {
+    if (!title) return "";
+    // Basic title case - you might want more sophisticated handling
+    return title.replace(/\{([^}]*)\}/g, '$1'); // Remove BibTeX braces
+  }
+
+  // Format date from citation-js date structure
+  formatDate(issued?: {['date-parts']: number[][]}): string {
+    if (!issued || !issued['date-parts'] || !issued['date-parts'][0]) {
+      return "";
+    }
+    
+    const dateParts = issued['date-parts'][0];
+    const year = dateParts[0];
+    const month = dateParts[1];
+    
+    if (month) {
+      const monthNames = [
+        "January", "February", "March", "April", "May", "June",
+        "July", "August", "September", "October", "November", "December"
+      ];
+      return `${monthNames[month - 1]} ${year}`;
+    }
+    
+    return year.toString();
+  }
+
+  // Format pages with proper en-dashes
+  formatPages(pages?: string): string {
+    if (!pages) return "";
+    
+    const hasRange = /[-–—]/.test(pages) || /,/.test(pages) || /\+/.test(pages);
+    const label = hasRange ? "pages" : "page";
+    const formattedPages = pages.replace(/-+/g, "–"); // Convert to en-dash
+    
+    return `${label} ${formattedPages}`;
+  }
+
+  // Generate bibliography entry for different types
+  formatEntry(entry: BibEntry, label: string): string {
+    const type = entry.type.toLowerCase();
+    
+    switch (type) {
+      case 'article':
+        return this.formatArticle(entry, label);
+      case 'book':
+        return this.formatBook(entry, label);
+      case 'inproceedings':
+      case 'conference':
+        return this.formatInProceedings(entry, label);
+      case 'incollection':
+        return this.formatInCollection(entry, label);
+      default:
+        console.warn(`Unsupported entry type: ${type}, falling back to article format`);
+        return this.formatArticle(entry, label);
+    }
+  }
+
+  private formatArticle(entry: BibEntry, label: string): string {
+    const parts: string[] = [];
+    
+    // Authors
+    if (entry.author) {
+      parts.push(this.formatAuthors(entry.author));
+    }
+    
+    // Title
+    if (entry.title) {
+      parts.push(this.formatTitle(entry.title));
+    }
+    
+    // Journal info
+    if (entry['container-title']) {
+      let journalPart = `*${entry['container-title']}*`; // Markdown emphasis
+      
+      // Volume and issue
+      if (entry.volume) {
+        journalPart += ` ${entry.volume}`;
+        if (entry.issue) {
+          journalPart += `(${entry.issue})`;
+        }
+      }
+      
+      // Pages
+      if (entry.page) {
+        journalPart += `:${entry.page.replace(/-+/g, "–")}`;
+      }
+      
+      parts.push(journalPart);
+    }
+    
+    // Date
+    if (entry.issued) {
+      parts.push(this.formatDate(entry.issued));
+    }
+    
+    return parts.join(", ") + ".";
+  }
+
+  private formatBook(entry: BibEntry, label: string): string {
+    const parts: string[] = [];
+    
+    // Authors or editors
+    if (entry.author) {
+      parts.push(this.formatAuthors(entry.author));
+    } else if (entry.editor) {
+      const editors = this.formatAuthors(entry.editor);
+      const suffix = entry.editor.length > 1 ? "editors" : "editor";
+      parts.push(`${editors}, ${suffix}`);
+    }
+    
+    // Title (emphasized)
+    if (entry.title) {
+      parts.push(`*${this.formatTitle(entry.title)}*`);
+    }
+    
+    // Publisher and place
+    const pubInfo: string[] = [];
+    if (entry['publisher-place']) {
+      pubInfo.push(entry['publisher-place']);
+    }
+    if (entry.publisher) {
+      pubInfo.push(entry.publisher);
+    }
+    if (pubInfo.length > 0) {
+      parts.push(pubInfo.join(": "));
+    }
+    
+    // Date
+    if (entry.issued) {
+      parts.push(this.formatDate(entry.issued));
+    }
+    
+    return parts.join(", ") + ".";
+  }
+
+  private formatInProceedings(entry: BibEntry, label: string): string {
+    const parts: string[] = [];
+    
+    // Authors
+    if (entry.author) {
+      parts.push(this.formatAuthors(entry.author));
+    }
+    
+    // Title
+    if (entry.title) {
+      parts.push(this.formatTitle(entry.title));
+    }
+    
+    // Booktitle
+    if (entry['container-title']) {
+      let proceedingsPart = `In *${entry['container-title']}*`;
+      
+      // Pages
+      if (entry.page) {
+        proceedingsPart += `, pages ${entry.page.replace(/-+/g, "–")}`;
+      }
+      
+      parts.push(proceedingsPart);
+    }
+    
+    // Date
+    if (entry.issued) {
+      parts.push(this.formatDate(entry.issued));
+    }
+    
+    return parts.join(", ") + ".";
+  }
+
+  private formatInCollection(entry: BibEntry, label: string): string {
+    // Similar to inproceedings but for book chapters
+    return this.formatInProceedings(entry, label);
+  }
+
+  // Generate complete bibliography
+  generateBibliography(entries: BibEntry[]): Array<{label: string, formatted: string, sortKey: string}> {
+    const formattedEntries = entries.map(entry => {
+      const label = this.generateAlphaLabel(entry);
+      const formatted = this.formatEntry(entry, label);
+      const sortKey = this.generateSortKey(entry, label);
+      
+      return { label, formatted, sortKey, entry };
+    });
+
+    // Handle duplicate labels (add 'a', 'b', etc.)
+    const labelCounts: {[key: string]: number} = {};
+    const finalEntries = formattedEntries.map(({label, formatted, sortKey, entry}) => {
+      if (labelCounts[label]) {
+        labelCounts[label]++;
+        const suffix = String.fromCharCode(96 + labelCounts[label]); // 'a', 'b', 'c'...
+        return {
+          label: label + suffix,
+          formatted,
+          sortKey: sortKey + suffix
+        };
+      } else {
+        labelCounts[label] = 1;
+        return { label, formatted, sortKey };
+      }
+    });
+
+    // Sort by sort key
+    finalEntries.sort((a, b) => a.sortKey.localeCompare(b.sortKey));
+    
+    return finalEntries;
+  }
+
+  private generateSortKey(entry: BibEntry, label: string): string {
+    // Simplified sort key for alpha style
+    const authorSort = entry.author ? 
+      entry.author[0].family || entry.author[0].literal || "" : 
+      (entry.editor ? entry.editor[0].family || entry.editor[0].literal || "" : "");
+    
+    const year = entry.issued?.['date-parts']?.[0]?.[0] || 9999;
+    const title = entry.title || "";
+    
+    return `${label}_${authorSort}_${year}_${title}`;
+  }
+
+  // Generate Markdown output suitable for Quartz
+  generateMarkdownBibliography(entries: BibEntry[]): string {
+    const bibliography = this.generateBibliography(entries);
+    
+    let output = "## Bibliography\n\n";
+    
+    for (const {label, formatted} of bibliography) {
+      // Use label as anchor for citations
+      output += `<div id="${label.toLowerCase()}" class="bib-entry">\n`;
+      output += `**[${label}]** ${formatted}\n`;
+      output += `</div>\n\n`;
+    }
+    
+    return output;
+  }
+
+  // Generate citation links for use in text
+  generateCitations(entries: BibEntry[]): {[key: string]: string} {
+    const bibliography = this.generateBibliography(entries);
+    const citations: {[key: string]: string} = {};
+    
+    for (const {label, entry} of bibliography as any[]) {
+      // Map original cite key to alpha label
+      citations[entry.entry.id] = `[${label}](#${label.toLowerCase()})`;
+    }
+    
+    return citations;
+  }
+}
+
+// Example usage for your Quartz site
+export async function setupAlphaCitations(bibFilePath: string) {
+  const alphaGen = new AlphaStyleGenerator();
+  
+  try {
+    // Parse your .bib file
+    const entries = await alphaGen.parseBibFromFile(bibFilePath);
+    console.log(`Loaded ${entries.length} bibliography entries`);
+    
+    // Generate bibliography
+    const markdown = alphaGen.generateMarkdownBibliography(entries);
+    
+    // Generate citation lookup
+    const citations = alphaGen.generateCitations(entries);
+    
+    return { markdown, citations, entries };
+  } catch (error) {
+    console.error('Failed to setup alpha citations:', error);
+    throw error;
+  }
+}
+
+// For browser usage (if loading .bib content directly)
+export async function setupAlphaCitationsFromContent(bibContent: string) {
+  const alphaGen = new AlphaStyleGenerator();
+  
+  const entries = await alphaGen.parseBibFile(bibContent);
+  const markdown = alphaGen.generateMarkdownBibliography(entries);
+  const citations = alphaGen.generateCitations(entries);
+  
+  return { markdown, citations, entries };
+}

--- a/quartz/plugins/transformers/alpha-citations.ts
+++ b/quartz/plugins/transformers/alpha-citations.ts
@@ -1,494 +1,356 @@
-// quartz/plugins/transformers/alpha-citations.ts
 import { QuartzTransformerPlugin, QuartzTransformerPluginInstance } from "../types"
-import { Root } from "mdast"
 import { visit } from "unist-util-visit"
-import { toString } from "mdast-util-to-string"
-import { Cite } from '@citation-js/core'
-import '@citation-js/plugin-bibtex'
+import { Element, Root } from "hast"
+import { VFile } from "vfile"
+import { BuildCtx } from "../../cfg"
 import path from "path"
 import fs from "fs"
 
-interface BibEntry {
-  id: string;
-  type: string;
-  author?: Array<{given: string, family: string, literal?: string}>;
-  editor?: Array<{given: string, family: string, literal?: string}>;
-  title?: string;
-  'container-title'?: string; // journal, booktitle
-  volume?: string | number;
-  issue?: string | number; // number field in BibTeX
-  page?: string;
-  'page-first'?: string;
-  issued?: {['date-parts']: number[][]}; // year, month
-  publisher?: string;
-  'publisher-place'?: string; // address
-  note?: string;
-  keyword?: string; // key field
-  [key: string]: any; // for additional fields
+// Import citation processing dependencies
+import { Cite } from "@citation-js/core"
+import "@citation-js/plugin-bibtex"
+import "@citation-js/plugin-csl"
+import rehypeCitation from "rehype-citation"
+
+interface AlphaCitationOptions {
+  bibliography: string | string[]
+  path?: string
+  linkCitations?: boolean
+  suppressBibliography?: boolean
+  locale?: string
 }
 
-interface AlphaCitationsOptions {
-  bibFile?: string; // Path to .bib file relative to content root
-  generateBibliographyPage?: boolean; // Whether to generate a dedicated bibliography page
-  bibliographyTitle?: string; // Title for the bibliography page
-  linkCitations?: boolean; // Whether to automatically link citations to bibliography
+interface AlphaLabel {
+  id: string
+  label: string
+  baseLabel: string
+  entry: any
 }
 
-class AlphaStyleGenerator {
-  private etAlCharUsed = false;
-  private citationCache: Map<string, string> = new Map();
-  private bibliographyEntries: Array<{label: string, formatted: string, sortKey: string, originalId: string}> = [];
-  
-  constructor() {}
+class AlphaLabelGenerator {
+  private labelCounts = new Map<string, number>()
+  private resolvedLabels = new Map<string, string>()
 
-  // Parse .bib file using citation-js
-  parseBibFile(bibContent: string): BibEntry[] {
-    try {
-      const cite = new Cite(bibContent, { forceType: '@bibtex/text' });
-      const entries = cite.data as BibEntry[];
-      
-      console.log('Parsed entries:', entries.length);
-      
-      return entries;
-    } catch (error) {
-      console.error('Error parsing BibTeX file:', error);
-      throw error;
-    }
-  }
+  generateLabels(entries: any[]): Map<string, string> {
+    // Step 1: Generate base labels
+    const baseLabels: AlphaLabel[] = entries.map(entry => ({
+      id: entry.id,
+      label: this.generateBaseLabel(entry),
+      baseLabel: this.generateBaseLabel(entry),
+      entry
+    }))
 
-  // Generate alpha-style label (e.g., "Knu79")
-  generateAlphaLabel(entry: BibEntry): string {
-    let authorPart = "";
+    // Step 2: Sort by base label for consistent ordering
+    baseLabels.sort((a, b) => a.baseLabel.localeCompare(b.baseLabel))
+
+    // Step 3: Resolve duplicates
+    const labelMap = new Map<string, string>()
     
-    // Handle different author/editor scenarios
-    if (entry.author && entry.author.length > 0) {
-      authorPart = this.formatLabNames(entry.author);
-    } else if (entry.editor && entry.editor.length > 0) {
-      authorPart = this.formatLabNames(entry.editor);
-    } else if (entry.keyword) {
-      // Use 'key' field if available
-      authorPart = entry.keyword.substring(0, 3).toUpperCase();
-    } else {
-      // Fallback to cite key
-      authorPart = entry.id.substring(0, 3).toUpperCase();
-    }
+    baseLabels.forEach(item => {
+      const finalLabel = this.resolveLabel(item.baseLabel, item.id)
+      labelMap.set(item.id, finalLabel)
+    })
 
-    // Extract year (last 2 digits)
-    let yearPart = "";
-    if (entry.issued && entry.issued['date-parts'] && entry.issued['date-parts'][0]) {
-      const year = entry.issued['date-parts'][0][0];
-      yearPart = year.toString().slice(-2);
-    }
-
-    return authorPart + yearPart;
+    return labelMap
   }
 
-  // Format author names for label generation
-  private formatLabNames(authors: Array<{given: string, family: string, literal?: string}>): string {
-    const numAuthors = authors.length;
+  private generateBaseLabel(entry: any): string {
+    const authors = this.extractAuthors(entry)
+    const year = this.extractYear(entry)
+    
+    const namepart = this.formatNames(authors)
+    const yearpart = year.toString().slice(-2).padStart(2, '0')
+    
+    return namepart + yearpart
+  }
+
+  private extractAuthors(entry: any): string[] {
+    if (entry.author && Array.isArray(entry.author)) {
+      return entry.author.map((author: any) => {
+        if (typeof author === 'string') return author
+        if (author.family) return author.family
+        if (author.literal) return author.literal
+        return String(author)
+      })
+    }
+    
+    if (entry.editor && Array.isArray(entry.editor)) {
+      return entry.editor.map((editor: any) => {
+        if (typeof editor === 'string') return editor
+        if (editor.family) return editor.family
+        if (editor.literal) return editor.literal
+        return String(editor)
+      })
+    }
+
+    // Fallback to title or entry id
+    if (entry.title) {
+      return [entry.title.substring(0, 3)]
+    }
+    
+    return [entry.id || 'UNK']
+  }
+
+  private extractYear(entry: any): number {
+    if (entry.issued && entry.issued['date-parts'] && entry.issued['date-parts'][0]) {
+      return entry.issued['date-parts'][0][0] || new Date().getFullYear()
+    }
+    
+    if (entry.year) {
+      const yearMatch = String(entry.year).match(/\d{4}/)
+      if (yearMatch) return parseInt(yearMatch[0])
+    }
+    
+    return new Date().getFullYear()
+  }
+
+  private formatNames(authors: string[]): string {
+    const numAuthors = authors.length
+    
+    if (numAuthors === 0) return "UNK"
     
     if (numAuthors === 1) {
-      const surname = authors[0].family || authors[0].literal || "";
-      return surname.length >= 3 ? surname.substring(0, 3).toUpperCase() : surname.toUpperCase();
+      return this.extractSurname(authors[0]).substring(0, 3).toUpperCase()
     }
     
-    if (numAuthors <= 3) {
-      // Use first letter of each surname
-      return authors
-        .map(author => (author.family || author.literal || "").charAt(0).toUpperCase())
-        .join("");
+    if (numAuthors >= 2 && numAuthors <= 4) {
+      return authors.map(name => 
+        this.extractSurname(name).charAt(0).toUpperCase()
+      ).join('')
     }
     
-    if (numAuthors === 4) {
-      // All four first letters
-      return authors
-        .map(author => (author.family || author.literal || "").charAt(0).toUpperCase())
-        .join("");
-    }
-    
-    // More than 4 authors: first 3 + "+"
-    const first3 = authors.slice(0, 3)
-      .map(author => (author.family || author.literal || "").charAt(0).toUpperCase())
-      .join("");
-    
-    this.etAlCharUsed = true;
-    return first3 + "+";
+    // 5+ authors
+    return this.extractSurname(authors[0]).substring(0, 3).toUpperCase() + '+'
   }
 
-  // Format author names for bibliography
-  formatAuthors(authors: Array<{given: string, family: string, literal?: string}>): string {
-    if (!authors || authors.length === 0) return "";
+  private extractSurname(fullName: string): string {
+    if (!fullName) return 'UNK'
     
-    const formatName = (author: {given: string, family: string, literal?: string}) => {
-      if (author.literal) return author.literal;
-      const given = author.given || "";
-      const family = author.family || "";
-      return given ? `${given} ${family}` : family;
-    };
-
-    if (authors.length === 1) {
-      return formatName(authors[0]);
-    } else if (authors.length === 2) {
-      return `${formatName(authors[0])} and ${formatName(authors[1])}`;
-    } else {
-      const allButLast = authors.slice(0, -1).map(formatName).join(", ");
-      return `${allButLast}, and ${formatName(authors[authors.length - 1])}`;
+    // Handle "Last, First" format
+    if (fullName.includes(',')) {
+      return fullName.split(',')[0].trim()
     }
+    
+    // Handle "First Last" format - get last word
+    const parts = fullName.trim().split(/\s+/)
+    return parts[parts.length - 1] || fullName
   }
 
-  // Format title with proper capitalization
-  formatTitle(title: string): string {
-    if (!title) return "";
-    // Basic title case - you might want more sophisticated handling
-    return title.replace(/\{([^}]*)\}/g, '$1'); // Remove BibTeX braces
+  private resolveLabel(baseLabel: string, entryId: string): string {
+    const count = this.labelCounts.get(baseLabel) || 0
+    this.labelCounts.set(baseLabel, count + 1)
+    
+    if (count === 0) {
+      this.resolvedLabels.set(entryId, baseLabel)
+      return baseLabel
+    }
+    
+    // Generate suffix: a, b, c, ... z, aa, ab, etc.
+    const suffix = this.generateSuffix(count)
+    const finalLabel = baseLabel + suffix
+    this.resolvedLabels.set(entryId, finalLabel)
+    
+    return finalLabel
   }
 
-  // Format date from citation-js date structure
-  formatDate(issued?: {['date-parts']: number[][]}): string {
-    if (!issued || !issued['date-parts'] || !issued['date-parts'][0]) {
-      return "";
+  private generateSuffix(count: number): string {
+    if (count < 26) {
+      return String.fromCharCode(97 + count - 1) // a-z
     }
     
-    const dateParts = issued['date-parts'][0];
-    const year = dateParts[0];
-    const month = dateParts[1];
-    
-    if (month) {
-      const monthNames = [
-        "January", "February", "March", "April", "May", "June",
-        "July", "August", "September", "October", "November", "December"
-      ];
-      return `${monthNames[month - 1]} ${year}`;
-    }
-    
-    return year.toString();
-  }
-
-  // Format entry for bibliography
-  formatEntry(entry: BibEntry): string {
-    const type = entry.type.toLowerCase();
-    
-    switch (type) {
-      case 'article':
-        return this.formatArticle(entry);
-      case 'book':
-        return this.formatBook(entry);
-      case 'inproceedings':
-      case 'conference':
-        return this.formatInProceedings(entry);
-      case 'incollection':
-        return this.formatInCollection(entry);
-      default:
-        console.warn(`Unsupported entry type: ${type}, falling back to article format`);
-        return this.formatArticle(entry);
-    }
-  }
-
-  private formatArticle(entry: BibEntry): string {
-    const parts: string[] = [];
-    
-    // Authors
-    if (entry.author) {
-      parts.push(this.formatAuthors(entry.author));
-    }
-    
-    // Title
-    if (entry.title) {
-      parts.push(this.formatTitle(entry.title));
-    }
-    
-    // Journal info
-    if (entry['container-title']) {
-      let journalPart = `*${entry['container-title']}*`; // Markdown emphasis
-      
-      // Volume and issue
-      if (entry.volume) {
-        journalPart += ` ${entry.volume}`;
-        if (entry.issue) {
-          journalPart += `(${entry.issue})`;
-        }
-      }
-      
-      // Pages
-      if (entry.page) {
-        journalPart += `:${entry.page.replace(/-+/g, "–")}`;
-      }
-      
-      parts.push(journalPart);
-    }
-    
-    // Date
-    if (entry.issued) {
-      parts.push(this.formatDate(entry.issued));
-    }
-    
-    return parts.join(", ") + ".";
-  }
-
-  private formatBook(entry: BibEntry): string {
-    const parts: string[] = [];
-    
-    // Authors or editors
-    if (entry.author) {
-      parts.push(this.formatAuthors(entry.author));
-    } else if (entry.editor) {
-      const editors = this.formatAuthors(entry.editor);
-      const suffix = entry.editor.length > 1 ? "editors" : "editor";
-      parts.push(`${editors}, ${suffix}`);
-    }
-    
-    // Title (emphasized)
-    if (entry.title) {
-      parts.push(`*${this.formatTitle(entry.title)}*`);
-    }
-    
-    // Publisher and place
-    const pubInfo: string[] = [];
-    if (entry['publisher-place']) {
-      pubInfo.push(entry['publisher-place']);
-    }
-    if (entry.publisher) {
-      pubInfo.push(entry.publisher);
-    }
-    if (pubInfo.length > 0) {
-      parts.push(pubInfo.join(": "));
-    }
-    
-    // Date
-    if (entry.issued) {
-      parts.push(this.formatDate(entry.issued));
-    }
-    
-    return parts.join(", ") + ".";
-  }
-
-  private formatInProceedings(entry: BibEntry): string {
-    const parts: string[] = [];
-    
-    // Authors
-    if (entry.author) {
-      parts.push(this.formatAuthors(entry.author));
-    }
-    
-    // Title
-    if (entry.title) {
-      parts.push(this.formatTitle(entry.title));
-    }
-    
-    // Booktitle
-    if (entry['container-title']) {
-      let proceedingsPart = `In *${entry['container-title']}*`;
-      
-      // Pages
-      if (entry.page) {
-        proceedingsPart += `, pages ${entry.page.replace(/-+/g, "–")}`;
-      }
-      
-      parts.push(proceedingsPart);
-    }
-    
-    // Date
-    if (entry.issued) {
-      parts.push(this.formatDate(entry.issued));
-    }
-    
-    return parts.join(", ") + ".";
-  }
-
-  private formatInCollection(entry: BibEntry): string {
-    // Similar to inproceedings but for book chapters
-    return this.formatInProceedings(entry);
-  }
-
-  // Generate complete bibliography
-  processBibliography(entries: BibEntry[]): Array<{label: string, formatted: string, sortKey: string, originalId: string}> {
-    const formattedEntries = entries.map(entry => {
-      const label = this.generateAlphaLabel(entry);
-      const formatted = this.formatEntry(entry);
-      const sortKey = this.generateSortKey(entry, label);
-      
-      return { label, formatted, sortKey, originalId: entry.id, entry };
-    });
-
-    // Handle duplicate labels (add 'a', 'b', etc.)
-    const labelCounts: {[key: string]: number} = {};
-    const finalEntries = formattedEntries.map(({label, formatted, sortKey, originalId, entry}) => {
-      if (labelCounts[label]) {
-        labelCounts[label]++;
-        const suffix = String.fromCharCode(96 + labelCounts[label]); // 'a', 'b', 'c'...
-        return {
-          label: label + suffix,
-          formatted,
-          sortKey: sortKey + suffix,
-          originalId
-        };
-      } else {
-        labelCounts[label] = 1;
-        return { label, formatted, sortKey, originalId };
-      }
-    });
-
-    // Sort by sort key
-    finalEntries.sort((a, b) => a.sortKey.localeCompare(b.sortKey));
-    
-    // Cache citations
-    for (const entry of finalEntries) {
-      this.citationCache.set(entry.originalId, entry.label);
-    }
-    
-    this.bibliographyEntries = finalEntries;
-    return finalEntries;
-  }
-
-  private generateSortKey(entry: BibEntry, label: string): string {
-    // Simplified sort key for alpha style
-    const authorSort = entry.author ? 
-      entry.author[0].family || entry.author[0].literal || "" : 
-      (entry.editor ? entry.editor[0].family || entry.editor[0].literal || "" : "");
-    
-    const year = entry.issued?.['date-parts']?.[0]?.[0] || 9999;
-    const title = entry.title || "";
-    
-    return `${label}_${authorSort}_${year}_${title}`;
-  }
-
-  // Get citation label for a given cite key
-  getCitationLabel(citeKey: string): string | undefined {
-    return this.citationCache.get(citeKey);
-  }
-
-  // Generate bibliography page content
-  generateBibliographyMarkdown(title: string = "Bibliography"): string {
-    let output = `# ${title}\n\n`;
-    
-    for (const {label, formatted} of this.bibliographyEntries) {
-      output += `<div id="${label.toLowerCase()}" class="bib-entry">\n`;
-      output += `**[${label}]** ${formatted}\n`;
-      output += `</div>\n\n`;
-    }
-    
-    return output;
+    // Handle aa, ab, ac, etc.
+    const base26 = Math.floor((count - 1) / 26)
+    const remainder = (count - 1) % 26
+    return String.fromCharCode(97 + base26 - 1) + 
+           String.fromCharCode(97 + remainder)
   }
 }
 
-export const AlphaCitations: QuartzTransformerPlugin<AlphaCitationsOptions | undefined> = (userOpts) => {
-  const opts: AlphaCitationsOptions = {
-    bibFile: "references.bib",
-    generateBibliographyPage: true,
-    bibliographyTitle: "Bibliography",
+export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions>> = (userOpts) => {
+  const opts: AlphaCitationOptions = {
+    bibliography: [],
+    path: process.cwd(),
     linkCitations: true,
+    suppressBibliography: false,
+    locale: 'en-US',
     ...userOpts,
   }
 
   return {
-    name: "AlphaCitations",
-    markdownPlugins() {
-      return []
-    },
-    htmlPlugins() {
-      return []
-    },
-    externalResources() {
-      return {}
-    },
-    async process(processor, ctx) {
-      const alphaGen = new AlphaStyleGenerator();
-      let bibEntries: BibEntry[] = [];
-      
-      // Try to load and parse the bibliography file
-      if (opts.bibFile) {
-        try {
-          const bibPath = path.join(ctx.cfg.configuration.contentDir || "content", opts.bibFile);
-          if (fs.existsSync(bibPath)) {
-            const bibContent = fs.readFileSync(bibPath, 'utf-8');
-            bibEntries = alphaGen.parseBibFile(bibContent);
-            alphaGen.processBibliography(bibEntries);
-            console.log(`Loaded ${bibEntries.length} bibliography entries for alpha citations`);
-            
-            // Generate bibliography page if requested
-            if (opts.generateBibliographyPage) {
-              const bibliographyMarkdown = alphaGen.generateBibliographyMarkdown(opts.bibliographyTitle);
-              const bibliographyPath = path.join(ctx.cfg.configuration.contentDir || "content", "bibliography.md");
-              fs.writeFileSync(bibliographyPath, bibliographyMarkdown);
-              console.log(`Generated bibliography page at ${bibliographyPath}`);
-            }
-          } else {
-            console.warn(`Bibliography file not found: ${bibPath}`);
-          }
-        } catch (error) {
-          console.error(`Error loading bibliography file: ${error}`);
-        }
+    name: "AlphaCitation",
+    
+    htmlPlugins(ctx: BuildCtx): any[] {
+      if (!opts.bibliography || (Array.isArray(opts.bibliography) && opts.bibliography.length === 0)) {
+        console.warn("AlphaCitation: No bibliography specified, skipping citation processing")
+        return []
       }
 
-      // Return a remark plugin that processes citations in markdown
-      return () => {
-        return (tree: Root, file) => {
-          if (bibEntries.length === 0) return;
-
-          // Process citation patterns like [@citekey] or [citekey]
-          visit(tree, 'text', (node: any) => {
-            if (!node.value) return;
-            
-            // Match patterns like [@citekey], [citekey], or [@citekey1; citekey2]
-            const citationRegex = /\[(@?)([^\]]+)\]/g;
-            
-            node.value = node.value.replace(citationRegex, (match: string, at: string, keys: string) => {
-              const citeKeys = keys.split(/[;,]/).map(k => k.trim().replace(/^@/, ''));
+      return [
+        // First, run standard rehype-citation to get the base structure
+        [rehypeCitation, {
+          bibliography: opts.bibliography,
+          path: opts.path,
+          csl: 'apa', // Use APA as base, we'll replace the labels
+          linkCitations: opts.linkCitations,
+          suppressBibliography: opts.suppressBibliography,
+          locale: opts.locale,
+        }],
+        
+        // Then post-process to apply alpha labels
+        function alphaLabelProcessor() {
+          return async (tree: Root, file: VFile) => {
+            try {
+              // Parse bibliography to generate alpha labels
+              const labelGenerator = new AlphaLabelGenerator()
+              const alphaLabels = await generateAlphaLabelsFromBib(opts, labelGenerator)
               
-              if (opts.linkCitations) {
-                const links = citeKeys.map(key => {
-                  const label = alphaGen.getCitationLabel(key);
-                  if (label) {
-                    return `[${label}](#${label.toLowerCase()})`;
-                  } else {
-                    console.warn(`Citation not found: ${key}`);
-                    return `[${key}]`;
-                  }
-                });
-                return `[${links.join(', ')}]`;
-              } else {
-                const labels = citeKeys.map(key => {
-                  const label = alphaGen.getCitationLabel(key);
-                  return label || key;
-                });
-                return `[${labels.join(', ')}]`;
-              }
-            });
-          });
-
-          // Also process paragraph nodes
-          visit(tree, 'paragraph', (node: any) => {
-            visit(node, 'text', (textNode: any) => {
-              if (!textNode.value) return;
-              
-              const citationRegex = /\[(@?)([^\]]+)\]/g;
-              
-              textNode.value = textNode.value.replace(citationRegex, (match: string, at: string, keys: string) => {
-                const citeKeys = keys.split(/[;,]/).map(k => k.trim().replace(/^@/, ''));
-                
-                if (opts.linkCitations) {
-                  const links = citeKeys.map(key => {
-                    const label = alphaGen.getCitationLabel(key);
-                    if (label) {
-                      return `[${label}](#${label.toLowerCase()})`;
-                    } else {
-                      console.warn(`Citation not found: ${key}`);
-                      return `[${key}]`;
-                    }
-                  });
-                  return `[${links.join(', ')}]`;
-                } else {
-                  const labels = citeKeys.map(key => {
-                    const label = alphaGen.getCitationLabel(key);
-                    return label || key;
-                  });
-                  return `[${labels.join(', ')}]`;
+              // Replace citation labels in the HTML tree
+              visit(tree, 'element', (node: Element) => {
+                // Replace inline citations
+                if (isInlineCitation(node)) {
+                  replaceCitationLabels(node, alphaLabels)
                 }
-              });
-            });
-          });
+                
+                // Replace bibliography entries
+                if (isBibliographyEntry(node)) {
+                  replaceBibliographyLabels(node, alphaLabels)
+                }
+              })
+            } catch (error) {
+              console.error("AlphaCitation processing error:", error)
+              // Continue processing even if alpha label generation fails
+            }
+          }
+        }
+      ]
+    },
+
+    externalResources() {
+      return {
+        css: [{
+          content: `
+            .alpha-citation {
+              font-weight: 500;
+              color: var(--primary-color, #2563eb);
+              text-decoration: none;
+            }
+            
+            .alpha-citation:hover {
+              text-decoration: underline;
+            }
+            
+            .alpha-label {
+              font-weight: 600;
+              margin-right: 0.5rem;
+              color: var(--text-color, #374151);
+            }
+            
+            .bibliography-entry {
+              margin-bottom: 1rem;
+              padding-left: 1rem;
+              text-indent: -1rem;
+            }
+          `
+        }]
+      }
+    }
+  } as QuartzTransformerPluginInstance
+}
+
+// Helper functions
+
+async function generateAlphaLabelsFromBib(
+  opts: AlphaCitationOptions, 
+  generator: AlphaLabelGenerator
+): Promise<Map<string, string>> {
+  try {
+    // Read and parse bibliography file(s)
+    const bibliographies = Array.isArray(opts.bibliography) ? opts.bibliography : [opts.bibliography]
+    let allEntries: any[] = []
+    
+    for (const bibFile of bibliographies) {
+      const bibPath = path.resolve(opts.path || process.cwd(), bibFile)
+      
+      if (!fs.existsSync(bibPath)) {
+        console.warn(`Bibliography file not found: ${bibPath}`)
+        continue
+      }
+      
+      const bibContent = fs.readFileSync(bibPath, 'utf8')
+      const cite = new Cite(bibContent)
+      const entries = cite.data
+      allEntries = allEntries.concat(entries)
+    }
+    
+    return generator.generateLabels(allEntries)
+  } catch (error) {
+    console.error("Error generating alpha labels:", error)
+    return new Map()
+  }
+}
+
+function isInlineCitation(node: Element): boolean {
+  return node.tagName === 'span' && 
+         node.properties?.className &&
+         Array.isArray(node.properties.className) &&
+         node.properties.className.includes('citation')
+}
+
+function isBibliographyEntry(node: Element): boolean {
+  return node.tagName === 'div' &&
+         node.properties?.className &&
+         Array.isArray(node.properties.className) &&
+         (node.properties.className.includes('csl-entry') || 
+          node.properties.className.includes('bibliography-entry'))
+}
+
+function replaceCitationLabels(node: Element, alphaLabels: Map<string, string>) {
+  visit(node, 'element', (child: Element) => {
+    if (child.tagName === 'a' && child.properties?.href) {
+      // Extract citation key from href (e.g., #bib-smith2020 -> smith2020)
+      const href = String(child.properties.href)
+      const match = href.match(/#(?:bib-)?(.+)$/)
+      
+      if (match && match[1]) {
+        const citationKey = match[1]
+        const alphaLabel = alphaLabels.get(citationKey)
+        
+        if (alphaLabel) {
+          // Replace the text content with alpha label
+          child.children = [{ type: 'text', value: `[${alphaLabel}]` }]
+          
+          // Add alpha citation class
+          const classes = Array.isArray(child.properties.className) 
+            ? child.properties.className 
+            : []
+          child.properties.className = [...classes, 'alpha-citation']
         }
       }
     }
-  } satisfies QuartzTransformerPluginInstance<AlphaCitationsOptions | undefined>
+  })
+}
+
+function replaceBibliographyLabels(node: Element, alphaLabels: Map<string, string>) {
+  // Extract citation key from id (e.g., bib-smith2020 -> smith2020)
+  if (node.properties?.id) {
+    const id = String(node.properties.id)
+    const match = id.match(/^(?:bib-)?(.+)$/)
+    
+    if (match && match[1]) {
+      const citationKey = match[1]
+      const alphaLabel = alphaLabels.get(citationKey)
+      
+      if (alphaLabel) {
+        // Prepend alpha label to bibliography entry
+        const labelElement: Element = {
+          type: 'element',
+          tagName: 'span',
+          properties: { className: ['alpha-label'] },
+          children: [{ type: 'text', value: `[${alphaLabel}]` }]
+        }
+        
+        node.children.unshift(labelElement, { type: 'text', value: ' ' })
+      }
+    }
+  }
 }

--- a/quartz/plugins/transformers/alpha-citations.ts
+++ b/quartz/plugins/transformers/alpha-citations.ts
@@ -1,8 +1,12 @@
-import Cite from '@citation-js/core'
+// quartz/plugins/transformers/alpha-citations.ts
+import { QuartzTransformerPlugin, QuartzTransformerPluginInstance } from "../types"
+import { Root } from "mdast"
+import { visit } from "unist-util-visit"
+import { toString } from "mdast-util-to-string"
+import { Cite } from '@citation-js/core'
 import '@citation-js/plugin-bibtex'
-
-// If you need to register the plugin explicitly:
-// plugins.input.add('@bibtex/text', ...)
+import path from "path"
+import fs from "fs"
 
 interface BibEntry {
   id: string;
@@ -23,34 +27,33 @@ interface BibEntry {
   [key: string]: any; // for additional fields
 }
 
+interface AlphaCitationsOptions {
+  bibFile?: string; // Path to .bib file relative to content root
+  generateBibliographyPage?: boolean; // Whether to generate a dedicated bibliography page
+  bibliographyTitle?: string; // Title for the bibliography page
+  linkCitations?: boolean; // Whether to automatically link citations to bibliography
+}
+
 class AlphaStyleGenerator {
   private etAlCharUsed = false;
+  private citationCache: Map<string, string> = new Map();
+  private bibliographyEntries: Array<{label: string, formatted: string, sortKey: string, originalId: string}> = [];
   
-  constructor() {
-    // Initialize citation-js if needed
-  }
+  constructor() {}
 
   // Parse .bib file using citation-js
-  async parseBibFile(bibContent: string): Promise<BibEntry[]> {
+  parseBibFile(bibContent: string): BibEntry[] {
     try {
       const cite = new Cite(bibContent, { forceType: '@bibtex/text' });
       const entries = cite.data as BibEntry[];
       
       console.log('Parsed entries:', entries.length);
-      console.log('Sample entry:', entries[0]); // Debug: see the structure
       
       return entries;
     } catch (error) {
       console.error('Error parsing BibTeX file:', error);
       throw error;
     }
-  }
-
-  // Alternative: load from file path (Node.js)
-  async parseBibFromFile(filePath: string): Promise<BibEntry[]> {
-    const fs = await import('fs/promises');
-    const bibContent = await fs.readFile(filePath, 'utf-8');
-    return this.parseBibFile(bibContent);
   }
 
   // Generate alpha-style label (e.g., "Knu79")
@@ -161,38 +164,27 @@ class AlphaStyleGenerator {
     return year.toString();
   }
 
-  // Format pages with proper en-dashes
-  formatPages(pages?: string): string {
-    if (!pages) return "";
-    
-    const hasRange = /[-–—]/.test(pages) || /,/.test(pages) || /\+/.test(pages);
-    const label = hasRange ? "pages" : "page";
-    const formattedPages = pages.replace(/-+/g, "–"); // Convert to en-dash
-    
-    return `${label} ${formattedPages}`;
-  }
-
-  // Generate bibliography entry for different types
-  formatEntry(entry: BibEntry, label: string): string {
+  // Format entry for bibliography
+  formatEntry(entry: BibEntry): string {
     const type = entry.type.toLowerCase();
     
     switch (type) {
       case 'article':
-        return this.formatArticle(entry, label);
+        return this.formatArticle(entry);
       case 'book':
-        return this.formatBook(entry, label);
+        return this.formatBook(entry);
       case 'inproceedings':
       case 'conference':
-        return this.formatInProceedings(entry, label);
+        return this.formatInProceedings(entry);
       case 'incollection':
-        return this.formatInCollection(entry, label);
+        return this.formatInCollection(entry);
       default:
         console.warn(`Unsupported entry type: ${type}, falling back to article format`);
-        return this.formatArticle(entry, label);
+        return this.formatArticle(entry);
     }
   }
 
-  private formatArticle(entry: BibEntry, label: string): string {
+  private formatArticle(entry: BibEntry): string {
     const parts: string[] = [];
     
     // Authors
@@ -233,7 +225,7 @@ class AlphaStyleGenerator {
     return parts.join(", ") + ".";
   }
 
-  private formatBook(entry: BibEntry, label: string): string {
+  private formatBook(entry: BibEntry): string {
     const parts: string[] = [];
     
     // Authors or editors
@@ -270,7 +262,7 @@ class AlphaStyleGenerator {
     return parts.join(", ") + ".";
   }
 
-  private formatInProceedings(entry: BibEntry, label: string): string {
+  private formatInProceedings(entry: BibEntry): string {
     const parts: string[] = [];
     
     // Authors
@@ -303,41 +295,48 @@ class AlphaStyleGenerator {
     return parts.join(", ") + ".";
   }
 
-  private formatInCollection(entry: BibEntry, label: string): string {
+  private formatInCollection(entry: BibEntry): string {
     // Similar to inproceedings but for book chapters
-    return this.formatInProceedings(entry, label);
+    return this.formatInProceedings(entry);
   }
 
   // Generate complete bibliography
-  generateBibliography(entries: BibEntry[]): Array<{label: string, formatted: string, sortKey: string}> {
+  processBibliography(entries: BibEntry[]): Array<{label: string, formatted: string, sortKey: string, originalId: string}> {
     const formattedEntries = entries.map(entry => {
       const label = this.generateAlphaLabel(entry);
-      const formatted = this.formatEntry(entry, label);
+      const formatted = this.formatEntry(entry);
       const sortKey = this.generateSortKey(entry, label);
       
-      return { label, formatted, sortKey, entry };
+      return { label, formatted, sortKey, originalId: entry.id, entry };
     });
 
     // Handle duplicate labels (add 'a', 'b', etc.)
     const labelCounts: {[key: string]: number} = {};
-    const finalEntries = formattedEntries.map(({label, formatted, sortKey, entry}) => {
+    const finalEntries = formattedEntries.map(({label, formatted, sortKey, originalId, entry}) => {
       if (labelCounts[label]) {
         labelCounts[label]++;
         const suffix = String.fromCharCode(96 + labelCounts[label]); // 'a', 'b', 'c'...
         return {
           label: label + suffix,
           formatted,
-          sortKey: sortKey + suffix
+          sortKey: sortKey + suffix,
+          originalId
         };
       } else {
         labelCounts[label] = 1;
-        return { label, formatted, sortKey };
+        return { label, formatted, sortKey, originalId };
       }
     });
 
     // Sort by sort key
     finalEntries.sort((a, b) => a.sortKey.localeCompare(b.sortKey));
     
+    // Cache citations
+    for (const entry of finalEntries) {
+      this.citationCache.set(entry.originalId, entry.label);
+    }
+    
+    this.bibliographyEntries = finalEntries;
     return finalEntries;
   }
 
@@ -353,14 +352,16 @@ class AlphaStyleGenerator {
     return `${label}_${authorSort}_${year}_${title}`;
   }
 
-  // Generate Markdown output suitable for Quartz
-  generateMarkdownBibliography(entries: BibEntry[]): string {
-    const bibliography = this.generateBibliography(entries);
+  // Get citation label for a given cite key
+  getCitationLabel(citeKey: string): string | undefined {
+    return this.citationCache.get(citeKey);
+  }
+
+  // Generate bibliography page content
+  generateBibliographyMarkdown(title: string = "Bibliography"): string {
+    let output = `# ${title}\n\n`;
     
-    let output = "## Bibliography\n\n";
-    
-    for (const {label, formatted} of bibliography) {
-      // Use label as anchor for citations
+    for (const {label, formatted} of this.bibliographyEntries) {
       output += `<div id="${label.toLowerCase()}" class="bib-entry">\n`;
       output += `**[${label}]** ${formatted}\n`;
       output += `</div>\n\n`;
@@ -368,50 +369,126 @@ class AlphaStyleGenerator {
     
     return output;
   }
+}
 
-  // Generate citation links for use in text
-  generateCitations(entries: BibEntry[]): {[key: string]: string} {
-    const bibliography = this.generateBibliography(entries);
-    const citations: {[key: string]: string} = {};
-    
-    for (const {label, entry} of bibliography as any[]) {
-      // Map original cite key to alpha label
-      citations[entry.entry.id] = `[${label}](#${label.toLowerCase()})`;
+export const AlphaCitations: QuartzTransformerPlugin<AlphaCitationsOptions | undefined> = (userOpts) => {
+  const opts: AlphaCitationsOptions = {
+    bibFile: "references.bib",
+    generateBibliographyPage: true,
+    bibliographyTitle: "Bibliography",
+    linkCitations: true,
+    ...userOpts,
+  }
+
+  return {
+    name: "AlphaCitations",
+    markdownPlugins() {
+      return []
+    },
+    htmlPlugins() {
+      return []
+    },
+    externalResources() {
+      return {}
+    },
+    async process(processor, ctx) {
+      const alphaGen = new AlphaStyleGenerator();
+      let bibEntries: BibEntry[] = [];
+      
+      // Try to load and parse the bibliography file
+      if (opts.bibFile) {
+        try {
+          const bibPath = path.join(ctx.cfg.configuration.contentDir || "content", opts.bibFile);
+          if (fs.existsSync(bibPath)) {
+            const bibContent = fs.readFileSync(bibPath, 'utf-8');
+            bibEntries = alphaGen.parseBibFile(bibContent);
+            alphaGen.processBibliography(bibEntries);
+            console.log(`Loaded ${bibEntries.length} bibliography entries for alpha citations`);
+            
+            // Generate bibliography page if requested
+            if (opts.generateBibliographyPage) {
+              const bibliographyMarkdown = alphaGen.generateBibliographyMarkdown(opts.bibliographyTitle);
+              const bibliographyPath = path.join(ctx.cfg.configuration.contentDir || "content", "bibliography.md");
+              fs.writeFileSync(bibliographyPath, bibliographyMarkdown);
+              console.log(`Generated bibliography page at ${bibliographyPath}`);
+            }
+          } else {
+            console.warn(`Bibliography file not found: ${bibPath}`);
+          }
+        } catch (error) {
+          console.error(`Error loading bibliography file: ${error}`);
+        }
+      }
+
+      // Return a remark plugin that processes citations in markdown
+      return () => {
+        return (tree: Root, file) => {
+          if (bibEntries.length === 0) return;
+
+          // Process citation patterns like [@citekey] or [citekey]
+          visit(tree, 'text', (node: any) => {
+            if (!node.value) return;
+            
+            // Match patterns like [@citekey], [citekey], or [@citekey1; citekey2]
+            const citationRegex = /\[(@?)([^\]]+)\]/g;
+            
+            node.value = node.value.replace(citationRegex, (match: string, at: string, keys: string) => {
+              const citeKeys = keys.split(/[;,]/).map(k => k.trim().replace(/^@/, ''));
+              
+              if (opts.linkCitations) {
+                const links = citeKeys.map(key => {
+                  const label = alphaGen.getCitationLabel(key);
+                  if (label) {
+                    return `[${label}](#${label.toLowerCase()})`;
+                  } else {
+                    console.warn(`Citation not found: ${key}`);
+                    return `[${key}]`;
+                  }
+                });
+                return `[${links.join(', ')}]`;
+              } else {
+                const labels = citeKeys.map(key => {
+                  const label = alphaGen.getCitationLabel(key);
+                  return label || key;
+                });
+                return `[${labels.join(', ')}]`;
+              }
+            });
+          });
+
+          // Also process paragraph nodes
+          visit(tree, 'paragraph', (node: any) => {
+            visit(node, 'text', (textNode: any) => {
+              if (!textNode.value) return;
+              
+              const citationRegex = /\[(@?)([^\]]+)\]/g;
+              
+              textNode.value = textNode.value.replace(citationRegex, (match: string, at: string, keys: string) => {
+                const citeKeys = keys.split(/[;,]/).map(k => k.trim().replace(/^@/, ''));
+                
+                if (opts.linkCitations) {
+                  const links = citeKeys.map(key => {
+                    const label = alphaGen.getCitationLabel(key);
+                    if (label) {
+                      return `[${label}](#${label.toLowerCase()})`;
+                    } else {
+                      console.warn(`Citation not found: ${key}`);
+                      return `[${key}]`;
+                    }
+                  });
+                  return `[${links.join(', ')}]`;
+                } else {
+                  const labels = citeKeys.map(key => {
+                    const label = alphaGen.getCitationLabel(key);
+                    return label || key;
+                  });
+                  return `[${labels.join(', ')}]`;
+                }
+              });
+            });
+          });
+        }
+      }
     }
-    
-    return citations;
-  }
-}
-
-// Example usage for your Quartz site
-export async function setupAlphaCitations(bibFilePath: string) {
-  const alphaGen = new AlphaStyleGenerator();
-  
-  try {
-    // Parse your .bib file
-    const entries = await alphaGen.parseBibFromFile(bibFilePath);
-    console.log(`Loaded ${entries.length} bibliography entries`);
-    
-    // Generate bibliography
-    const markdown = alphaGen.generateMarkdownBibliography(entries);
-    
-    // Generate citation lookup
-    const citations = alphaGen.generateCitations(entries);
-    
-    return { markdown, citations, entries };
-  } catch (error) {
-    console.error('Failed to setup alpha citations:', error);
-    throw error;
-  }
-}
-
-// For browser usage (if loading .bib content directly)
-export async function setupAlphaCitationsFromContent(bibContent: string) {
-  const alphaGen = new AlphaStyleGenerator();
-  
-  const entries = await alphaGen.parseBibFile(bibContent);
-  const markdown = alphaGen.generateMarkdownBibliography(entries);
-  const citations = alphaGen.generateCitations(entries);
-  
-  return { markdown, citations, entries };
+  } satisfies QuartzTransformerPluginInstance<AlphaCitationsOptions | undefined>
 }

--- a/quartz/plugins/transformers/alphaCitations.ts
+++ b/quartz/plugins/transformers/alphaCitations.ts
@@ -1,6 +1,6 @@
 import { QuartzTransformerPlugin, QuartzTransformerPluginInstance } from "../types"
 import { visit } from "unist-util-visit"
-import { Element, Root } from "hast"
+import { Element, Root, Text } from "hast"
 import { VFile } from "vfile"
 import { BuildCtx } from "../../cfg"
 import path from "path"
@@ -208,14 +208,11 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
               const labelGenerator = new AlphaLabelGenerator()
               const { alphaLabels, entryData } = await generateAlphaLabelsFromBib(opts, labelGenerator)
               
-              // Replace citation labels in the HTML tree
+              // Replace citation labels throughout the entire HTML tree
+              replaceCitationLabels(tree, alphaLabels)
+              
+              // Replace bibliography entries
               visit(tree, 'element', (node: Element) => {
-                // Replace inline citations
-                if (isInlineCitation(node)) {
-                  replaceCitationLabels(node, alphaLabels)
-                }
-                
-                // Replace bibliography entries
                 if (isBibliographyEntry(node)) {
                   replaceBibliographyLabels(node, alphaLabels, entryData)
                 }
@@ -256,17 +253,16 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
             }
             
             .bibliography-url {
-              display: inline-block;
-              margin-left: 0.5rem;
-              padding: 0.25rem 0.5rem;
-              background-color: var(--bg-secondary, #f3f4f6);
               color: var(--primary-color, #2563eb);
-              text-decoration: none;
-              border-radius: 0.25rem;
+              text-decoration: underline;
               font-size: 0.875rem;
-              font-weight: 500;
-              border: 1px solid var(--border-color, #e5e7eb);
+              font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+              background-color: var(--bg-secondary, #f8fafc);
+              padding: 0.125rem 0.375rem;
+              border-radius: 0.25rem;
+              border: 1px solid var(--border-color, #e2e8f0);
               transition: all 0.15s ease-in-out;
+              word-break: break-all;
             }
             
             .bibliography-url:hover {
@@ -274,12 +270,12 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
               color: white;
               text-decoration: none;
               transform: translateY(-1px);
-              box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+              box-shadow: 0 2px 4px rgba(37, 99, 235, 0.2);
             }
             
             .bibliography-url:active {
               transform: translateY(0);
-              box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+              box-shadow: 0 1px 2px rgba(37, 99, 235, 0.1);
             }
           `
         }]
@@ -393,39 +389,58 @@ function replaceBibliographyLabels(node: Element, alphaLabels: Map<string, strin
         
         node.children.unshift(labelElement, { type: 'text', value: ' ' })
         
-        // Add URL link if available
+        // Convert existing URLs to hyperlinks if available
         if (entry) {
-          addUrlLinkToBibEntry(node, entry)
+          convertUrlsToHyperlinks(node, entry)
         }
       }
     }
   }
 }
 
-function addUrlLinkToBibEntry(node: Element, entry: any) {
-  // Extract URL from various possible fields
+function convertUrlsToHyperlinks(node: Element, entry: any) {
   const url = extractUrl(entry)
   
-  if (url) {
-    // Create URL link element
-    const linkElement: Element = {
-      type: 'element',
-      tagName: 'a',
-      properties: {
-        href: url,
-        target: '_blank',
-        rel: 'noopener noreferrer',
-        className: ['bibliography-url']
-      },
-      children: [{ type: 'text', value: ' ' }]
-    }
+  if (!url) return
+  
+  // Find all text nodes and replace URLs with hyperlinks
+  visit(node, 'text', (textNode: Text, index, parent) => {
+    if (!parent || typeof index !== 'number') return
     
-    // Add spacing and the link at the end of the bibliography entry
-    node.children.push(
-      { type: 'text', value: ' ' },
-      linkElement
-    )
-  }
+    const text = textNode.value
+    
+    // Check if this text node contains the URL
+    if (text.includes(url)) {
+      // Split the text around the URL
+      const parts = text.split(url)
+      const newChildren = []
+      
+      for (let i = 0; i < parts.length; i++) {
+        // Add text part
+        if (parts[i]) {
+          newChildren.push({ type: 'text', value: parts[i] })
+        }
+        
+        // Add hyperlinked URL (except after the last part)
+        if (i < parts.length - 1) {
+          newChildren.push({
+            type: 'element',
+            tagName: 'a',
+            properties: {
+              href: url,
+              target: '_blank',
+              rel: 'noopener noreferrer',
+              className: ['bibliography-url']
+            },
+            children: [{ type: 'text', value: url }]
+          })
+        }
+      }
+      
+      // Replace the original text node with the new children
+      parent.children.splice(index, 1, ...newChildren)
+    }
+  })
 }
 
 function extractUrl(entry: any): string | null {

--- a/quartz/plugins/transformers/alphaCitations.ts
+++ b/quartz/plugins/transformers/alphaCitations.ts
@@ -204,9 +204,9 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
         function alphaLabelProcessor() {
           return async (tree: Root, file: VFile) => {
             try {
-              // Parse bibliography to generate alpha labels
+              // Parse bibliography to generate alpha labels and get entry data
               const labelGenerator = new AlphaLabelGenerator()
-              const alphaLabels = await generateAlphaLabelsFromBib(opts, labelGenerator)
+              const { alphaLabels, entryData } = await generateAlphaLabelsFromBib(opts, labelGenerator)
               
               // Replace citation labels in the HTML tree
               visit(tree, 'element', (node: Element) => {
@@ -217,7 +217,7 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
                 
                 // Replace bibliography entries
                 if (isBibliographyEntry(node)) {
-                  replaceBibliographyLabels(node, alphaLabels)
+                  replaceBibliographyLabels(node, alphaLabels, entryData)
                 }
               })
             } catch (error) {
@@ -254,6 +254,33 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
               padding-left: 1rem;
               text-indent: -1rem;
             }
+            
+            .bibliography-url {
+              display: inline-block;
+              margin-left: 0.5rem;
+              padding: 0.25rem 0.5rem;
+              background-color: var(--bg-secondary, #f3f4f6);
+              color: var(--primary-color, #2563eb);
+              text-decoration: none;
+              border-radius: 0.25rem;
+              font-size: 0.875rem;
+              font-weight: 500;
+              border: 1px solid var(--border-color, #e5e7eb);
+              transition: all 0.15s ease-in-out;
+            }
+            
+            .bibliography-url:hover {
+              background-color: var(--primary-color, #2563eb);
+              color: white;
+              text-decoration: none;
+              transform: translateY(-1px);
+              box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+            }
+            
+            .bibliography-url:active {
+              transform: translateY(0);
+              box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+            }
           `
         }]
       }
@@ -266,7 +293,7 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
 async function generateAlphaLabelsFromBib(
   opts: AlphaCitationOptions, 
   generator: AlphaLabelGenerator
-): Promise<Map<string, string>> {
+): Promise<{ alphaLabels: Map<string, string>, entryData: Map<string, any> }> {
   try {
     // Read and parse bibliography file(s)
     const bibliographies = Array.isArray(opts.bibliography) ? opts.bibliography : [opts.bibliography]
@@ -286,10 +313,20 @@ async function generateAlphaLabelsFromBib(
       allEntries = allEntries.concat(entries)
     }
     
-    return generator.generateLabels(allEntries)
+    const alphaLabels = generator.generateLabels(allEntries)
+    
+    // Create entry data map for easy lookup
+    const entryData = new Map<string, any>()
+    allEntries.forEach(entry => {
+      if (entry.id) {
+        entryData.set(entry.id, entry)
+      }
+    })
+    
+    return { alphaLabels, entryData }
   } catch (error) {
     console.error("Error generating alpha labels:", error)
-    return new Map()
+    return { alphaLabels: new Map(), entryData: new Map() }
   }
 }
 
@@ -334,7 +371,7 @@ function replaceCitationLabels(node: Element, alphaLabels: Map<string, string>) 
   })
 }
 
-function replaceBibliographyLabels(node: Element, alphaLabels: Map<string, string>) {
+function replaceBibliographyLabels(node: Element, alphaLabels: Map<string, string>, entryData: Map<string, any>) {
   // Extract citation key from id (e.g., bib-smith2020 -> smith2020)
   if (node.properties?.id) {
     const id = String(node.properties.id)
@@ -343,6 +380,7 @@ function replaceBibliographyLabels(node: Element, alphaLabels: Map<string, strin
     if (match && match[1]) {
       const citationKey = match[1]
       const alphaLabel = alphaLabels.get(citationKey)
+      const entry = entryData.get(citationKey)
       
       if (alphaLabel) {
         // Prepend alpha label to bibliography entry
@@ -354,7 +392,69 @@ function replaceBibliographyLabels(node: Element, alphaLabels: Map<string, strin
         }
         
         node.children.unshift(labelElement, { type: 'text', value: ' ' })
+        
+        // Add URL link if available
+        if (entry) {
+          addUrlLinkToBibEntry(node, entry)
+        }
       }
     }
   }
+}
+
+function addUrlLinkToBibEntry(node: Element, entry: any) {
+  // Extract URL from various possible fields
+  const url = extractUrl(entry)
+  
+  if (url) {
+    // Create URL link element
+    const linkElement: Element = {
+      type: 'element',
+      tagName: 'a',
+      properties: {
+        href: url,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+        className: ['bibliography-url']
+      },
+      children: [{ type: 'text', value: ' ' }]
+    }
+    
+    // Add spacing and the link at the end of the bibliography entry
+    node.children.push(
+      { type: 'text', value: ' ' },
+      linkElement
+    )
+  }
+}
+
+function extractUrl(entry: any): string | null {
+  // Check for URL field first
+  if (entry.URL && typeof entry.URL === 'string') {
+    return entry.URL
+  }
+  
+  if (entry.url && typeof entry.url === 'string') {
+    return entry.url
+  }
+  
+  // Check for DOI and convert to URL
+  if (entry.DOI && typeof entry.DOI === 'string') {
+    return `https://doi.org/${entry.DOI}`
+  }
+  
+  if (entry.doi && typeof entry.doi === 'string') {
+    return `https://doi.org/${entry.doi}`
+  }
+  
+  // Check for arXiv ID and convert to URL
+  if (entry.archivePrefix === 'arXiv' && entry.eprint) {
+    return `https://arxiv.org/abs/${entry.eprint}`
+  }
+  
+  if (entry.eprint && typeof entry.eprint === 'string' && entry.eprint.match(/^\d{4}\.\d{4,5}$/)) {
+    return `https://arxiv.org/abs/${entry.eprint}`
+  }
+  
+  return null
 }

--- a/quartz/plugins/transformers/alphaCitations.ts
+++ b/quartz/plugins/transformers/alphaCitations.ts
@@ -455,11 +455,11 @@ function extractUrl(entry: any): string | null {
   
   // Check for DOI and convert to URL
   if (entry.DOI && typeof entry.DOI === 'string') {
-    return `https://doi.org/${entry.DOI}`
+    return entry.DOI
   }
   
   if (entry.doi && typeof entry.doi === 'string') {
-    return `https://doi.org/${entry.doi}`
+    return entry.doi
   }
   
   // Check for arXiv ID and convert to URL

--- a/quartz/plugins/transformers/citations.ts
+++ b/quartz/plugins/transformers/citations.ts
@@ -8,23 +8,26 @@ export interface Options {
   suppressBibliography: boolean
   linkCitations: boolean
   csl: string
+  useAlphabeticStyle: boolean
 }
 
 const defaultOptions: Options = {
   bibliographyFile: "./bibliography.bib",
   suppressBibliography: false,
   linkCitations: true,
-  csl: "alpha",
+  csl: "apa",
+  useAlphabeticStyle: true
 }
 
 export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) => {
   const opts = { ...defaultOptions, ...userOpts }
+  
   return {
     name: "Citations",
     htmlPlugins(ctx) {
       const plugins: PluggableList = []
 
-      // Add rehype-citation to the list of plugins
+      // Add standard rehype-citation plugin
       plugins.push([
         rehypeCitation,
         {
@@ -36,12 +39,132 @@ export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) =
         },
       ])
 
-      // Transform the HTML of the citattions; add data-no-popover property to the citation links
-      // using https://github.com/syntax-tree/unist-util-visit as they're just anochor links
+      if (opts.useAlphabeticStyle) {
+        // Transform to alphabetic style after standard processing
+        plugins.push(() => {
+          return (tree, _file) => {
+            const bibliographyEntries: any[] = []
+
+            // First pass: Extract bibliography entries
+            visit(tree, "element", (node, _index, _parent) => {
+              if (node.tagName === "div" && 
+                  Array.isArray(node.properties?.className) &&
+                  node.properties.className.includes("csl-entry")) {
+                
+                const bibId = node.properties?.id as string
+                if (bibId) {
+                  const entry = extractBibDataFromHTML(node, bibId)
+                  bibliographyEntries.push(entry)
+                }
+              }
+            })
+
+            // Generate alphabetic labels
+            if (bibliographyEntries.length > 0) {
+              const alphaEntries = generateAlphabeticLabels(bibliographyEntries)
+              
+              // Create citation mapping
+              const citationMap = new Map<string, string>()
+              alphaEntries.forEach(entry => {
+                citationMap.set(`#${entry.id}`, entry.alphaLabel)
+                citationMap.set(`#bib-${entry.id}`, entry.alphaLabel)
+              })
+
+              // Second pass: Update citation links
+              visit(tree, "element", (node, _index, _parent) => {
+                if (node.tagName === "a" && 
+                    typeof node.properties?.href === "string" &&
+                    node.properties.href.startsWith("#")) {
+                  
+                  const href = node.properties.href as string
+                  const alphaLabel = citationMap.get(href)
+                  
+                  if (alphaLabel) {
+                    node.children = [{
+                      type: "text",
+                      value: `[${alphaLabel}]`
+                    }]
+                    node.properties["data-no-popover"] = true
+                  }
+                }
+              })
+
+              // Third pass: Update bibliography entries
+              visit(tree, "element", (node, _index, _parent) => {
+                if (node.tagName === "div" && 
+                    Array.isArray(node.properties?.className) &&
+                    node.properties.className.includes("csl-entry")) {
+                  
+                  const bibId = (node.properties?.id as string)?.replace("bib-", "") || ""
+                  const alphaEntry = alphaEntries.find(e => e.id === bibId)
+                  
+                  if (alphaEntry) {
+                    const originalText = getTextContent(node)
+                    
+                    node.children = [
+                      {
+                        type: "element",
+                        tagName: "strong",
+                        properties: { className: ["alpha-label"] },
+                        children: [{ 
+                          type: "text", 
+                          value: `[${alphaEntry.alphaLabel}] ` 
+                        }]
+                      },
+                      {
+                        type: "text",
+                        value: originalText
+                      }
+                    ]
+                  }
+                }
+              })
+
+              // Fourth pass: Sort bibliography alphabetically
+              visit(tree, "element", (node, _index, _parent) => {
+                if (node.tagName === "div" && 
+                    Array.isArray(node.properties?.className) &&
+                    node.properties.className.includes("csl-bib-body")) {
+                  
+                  const entries = node.children.filter((child: any) => 
+                    child.type === "element" && 
+                    child.tagName === "div" &&
+                    Array.isArray(child.properties?.className) &&
+                    child.properties.className.includes("csl-entry")
+                  ) as any[]
+                  
+                  entries.sort((a, b) => {
+                    const aId = (a.properties?.id as string)?.replace("bib-", "") || ""
+                    const bId = (b.properties?.id as string)?.replace("bib-", "") || ""
+                    const aEntry = alphaEntries.find(e => e.id === aId)
+                    const bEntry = alphaEntries.find(e => e.id === bId)
+                    
+                    if (!aEntry || !bEntry) return 0
+                    return aEntry.alphaLabel.localeCompare(bEntry.alphaLabel)
+                  })
+                  
+                  const otherChildren = node.children.filter((child: any) => 
+                    !(child.type === "element" && 
+                      child.tagName === "div" &&
+                      Array.isArray(child.properties?.className) &&
+                      child.properties.className.includes("csl-entry"))
+                  )
+                  
+                  node.children = [...otherChildren, ...entries]
+                }
+              })
+            }
+          }
+        })
+      }
+
+      // Add data-no-popover to all citation links
       plugins.push(() => {
         return (tree, _file) => {
           visit(tree, "element", (node, _index, _parent) => {
-            if (node.tagName === "a" && node.properties?.href?.startsWith("#bib")) {
+            if (node.tagName === "a" && 
+                typeof node.properties?.href === "string" &&
+                node.properties.href.startsWith("#bib")) {
               node.properties["data-no-popover"] = true
             }
           })
@@ -51,4 +174,126 @@ export const Citations: QuartzTransformerPlugin<Partial<Options>> = (userOpts) =
       return plugins
     },
   }
+}
+
+// Helper functions for alphabetic citation generation
+function generateAlphabeticLabels(entries: any[]) {
+  const alphaEntries = entries.map(entry => {
+    const authors = extractAuthorsFromText(entry.textContent || "")
+    const year = extractYearFromText(entry.textContent || "")
+    const alphaLabel = generateAlphaLabel(authors, year)
+    
+    return {
+      ...entry,
+      alphaLabel,
+      sortKey: alphaLabel,
+      authors,
+      year
+    }
+  })
+  
+  return resolveConflicts(alphaEntries)
+}
+
+function generateAlphaLabel(authors: string[], year: string): string {
+  const yearShort = year.slice(-2)
+  
+  if (authors.length === 1) {
+    const surname = authors[0]
+    const prefix = surname.slice(0, 3)
+    return `${prefix}${yearShort}`
+  } else if (authors.length <= 3) {
+    const prefix = authors.map(author => author.charAt(0)).join('')
+    return `${prefix}${yearShort}`
+  } else {
+    const firstAuthor = authors[0]
+    const prefix = firstAuthor.slice(0, 3) + '+'
+    return `${prefix}${yearShort}`
+  }
+}
+
+function resolveConflicts(entries: any[]): any[] {
+  const labelGroups = new Map<string, any[]>()
+  
+  for (const entry of entries) {
+    const baseLabel = entry.alphaLabel
+    if (!labelGroups.has(baseLabel)) {
+      labelGroups.set(baseLabel, [])
+    }
+    labelGroups.get(baseLabel)!.push(entry)
+  }
+  
+  const result: any[] = []
+  const sortedLabels = Array.from(labelGroups.keys()).sort()
+  
+  for (const baseLabel of sortedLabels) {
+    const group = labelGroups.get(baseLabel)!
+    
+    if (group.length === 1) {
+      result.push(group[0])
+    } else {
+      group.forEach((entry, index) => {
+        const suffix = String.fromCharCode(97 + index)
+        const resolvedEntry = {
+          ...entry,
+          alphaLabel: baseLabel + suffix,
+          sortKey: baseLabel + suffix
+        }
+        result.push(resolvedEntry)
+      })
+    }
+  }
+  
+  return result.sort((a, b) => a.sortKey.localeCompare(b.sortKey))
+}
+
+function extractBibDataFromHTML(node: any, bibId: string): any {
+  const textContent = getTextContent(node)
+  
+  return {
+    id: bibId.replace("bib-", ""),
+    textContent,
+    htmlNode: node
+  }
+}
+
+function getTextContent(element: any): string {
+  let text = ""
+  
+  function traverse(node: any) {
+    if (node.type === "text") {
+      text += node.value
+    } else if (node.children) {
+      node.children.forEach(traverse)
+    }
+  }
+  
+  traverse(element)
+  return text
+}
+
+function extractTitleFromText(text: string): string {
+  const titleMatch = text.match(/"([^"]+)"/)
+  return titleMatch ? titleMatch[1] : text.split('.')[0]
+}
+
+function extractAuthorsFromText(text: string): string[] {
+  const authorMatch = text.match(/^([^.]+)\./)
+  if (!authorMatch) return ['Unknown']
+  
+  const authorString = authorMatch[1]
+  const authors = authorString.split(/,|\sand\s/)
+    .map(author => author.trim())
+    .filter(author => author.length > 0)
+    .map(author => {
+      const parts = author.split(/\s+/)
+      return parts[parts.length - 1].replace(/[.,]$/, '')
+    })
+  
+  return authors.length > 0 ? authors : ['Unknown']
+}
+
+function extractYearFromText(text: string): string {
+  const yearMatch = text.match(/\b(19|20)\d{2}\b/)
+  return yearMatch ? yearMatch[0] : "0000"
 }

--- a/quartz/plugins/transformers/index.ts
+++ b/quartz/plugins/transformers/index.ts
@@ -1,6 +1,7 @@
 export { FrontMatter } from "./frontmatter"
 export { GitHubFlavoredMarkdown } from "./gfm"
 export { Citations } from "./citations"
+export { AlphaCitation } from "./alpha-citations"
 export { CreatedModifiedDate } from "./lastmod"
 export { Pseudocode } from "./pseudocode"
 export { Latex } from "./latex"

--- a/quartz/plugins/transformers/index.ts
+++ b/quartz/plugins/transformers/index.ts
@@ -1,7 +1,7 @@
 export { FrontMatter } from "./frontmatter"
 export { GitHubFlavoredMarkdown } from "./gfm"
 export { Citations } from "./citations"
-export { AlphaCitation } from "./alpha-citations"
+export { AlphaCitation } from "./alphaCitations"
 export { CreatedModifiedDate } from "./lastmod"
 export { Pseudocode } from "./pseudocode"
 export { Latex } from "./latex"

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -22,3 +22,45 @@
   text-align: center;
   text-decoration: none;
 }
+
+// Alphabetic citation styling
+.csl-entry {
+  .alpha-label {
+    color: var(--secondary);
+    font-weight: 600;
+    margin-right: 0.5em;
+    font-family: 'Courier New', monospace;
+  }
+}
+
+// Citation links
+a[href^="#bib"] {
+  color: var(--secondary);
+  text-decoration: none;
+  font-weight: 500;
+  font-family: 'Courier New', monospace;
+  
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+// Bibliography container
+.csl-bib-body {
+  .csl-entry {
+    margin-bottom: 1em;
+    padding-left: 0;
+    text-indent: 0;
+    
+    // Hanging indent for bibliography entries
+    margin-left: 2em;
+    text-indent: -2em;
+  }
+}
+
+// Multiple citations styling
+.citation-multiple {
+  .citation-item {
+    margin-right: 0.3em;
+  }
+}


### PR DESCRIPTION
Integrate with Quartz's existing rehype-citation infrastructure (don't replace it, extend it)

Use @citation-js/plugin-bibtex to parse my bibliography.bib file and extract structured author/year data

Generate alpha-style labels following LaTeX alpha.bst rules:



1 author: [Knu79] (first 3 letters of surname + last 2 digits of year)

2-4 authors: [FSJC16] (first letter of each author's surname + year)

5+ authors: [Sut+17] (first 3 letters of first author + "+" + year)

Handle duplicates with suffixes: [Smi20a], [Smi20b], etc.





Keep all existing rehype-citation functionality ([@citation] parsing, bibliography generation, etc.)

Create a custom CSL style or modify rehype-citation's output to use alpha formatting