### PR TITLE
All markdowns with proper citation completed, BIG PUSH

### DIFF
--- a/bibliography.bib
+++ b/bibliography.bib
@@ -1,15 +1,15 @@
 // 02-cryptographic-primitives->2.2
 @techreport{rogawayshrimpton2004,
-  author       = {Phillip Rogaway and Thomas Shrimpton},
-  title        = {Cryptographic Hash-Function Basics: Definitions, Implications and Separations for Preimage Resistance, Second-Preimage Resistance, and Collision Resistance},
-  institution  = {Cryptology ePrint Archive},
-  number       = {2004/035},
-  year         = {2004},
-  type         = {eprint},
-  url          = {https://eprint.iacr.org/2004/035.pdf}
+  author={Phillip Rogaway and Thomas Shrimpton},
+  title={Cryptographic Hash-Function Basics: Definitions, Implications and Separations for Preimage Resistance, Second-Preimage Resistance, and Collision Resistance},
+  institution={Cryptology ePrint Archive},
+  number={2004/035},
+  year={2004},
+  type={eprint},
+  url={https://eprint.iacr.org/2004/035.pdf}
 }
 
-// 06-chain-virtues->6.8
+  // 06-chain-virtues->6.8
 @article{lamport1982byzantine,
   author={Leslie Lamport and Robert Shostak and Marshall Pease},
   title={The Byzantine Generals Problem},
@@ -19,11 +19,11 @@
   pages={382--401},
   year={1982},
   publisher={ACM},
-  % doi={10.1145/357172.357176},
+  doi={10.1145/357172.357176},
   url={https://lamport.azurewebsites.net/pubs/byz.pdf}
 }
 
-// 06-chain-virtues->6.8
+  // 06-chain-virtues->6.8
 @article{nakamoto2008bitcoin,
   title={Bitcoin: A peer-to-peer electronic cash system},
   author={Nakamoto, Satoshi},
@@ -31,7 +31,7 @@
   url={https://bitcoin.org/bitcoin.pdf}
 }
 
-// 06-chain-virtues->6.8
+  // 06-chain-virtues->6.8
 @article{kiayias2015speed,
   title={Speed-security tradeoffs in blockchain protocols},
   author={Kiayias, Aggelos and Panagiotakos, Giorgos},
@@ -41,7 +41,7 @@
 }
 
 
-// 2-Probability->2.6.3.2
+  // 2-Probability->2.6.3.2
 @article{halevy2009unreasonable,
   title={The unreasonable effectiveness of data},
   author={Halevy, Alon and Norvig, Peter and Pereira, Fernando},
@@ -54,7 +54,7 @@
   url={https://research.google.com/pubs/archive/35179.pdf}
 }
 
-// 02-probability->2.7.1.2
+  // 02-probability->2.7.1.2
 @article{minka2005divergence,
   title={Divergence measures and message passing},
   author={Minka, Tom},
@@ -63,77 +63,75 @@
   url={https://miat.inrae.fr/AIGM/biblios/TR-2005-173.pdf}
 }
 
-// 2-Probability->2.7.3.3
+  // 2-probability->2.7.3.3
 @misc{chwialkowski2015fasttwosampletestinganalytic,
-      title={Fast Two-Sample Testing with Analytic Representations of Probability Measures}, 
-      author={Kacper Chwialkowski and Aaditya Ramdas and Dino Sejdinovic and Arthur Gretton},
-      year={2015},
-      eprint={1506.04725},
-      archivePrefix={arXiv},
-      primaryClass={stat.ML},
-      url={https://arxiv.org/abs/1506.04725}, 
+  title={Fast Two-Sample Testing with Analytic Representations of Probability Measures}, 
+  author={Kacper Chwialkowski and Aaditya Ramdas and Dino Sejdinovic and Arthur Gretton},
+  year={2015},
+  eprint={1506.04725},
+  archivePrefix={arXiv},
+  primaryClass={stat.ML},
+  url={https://arxiv.org/abs/1506.04725}, 
 }
 
-// 2-Probability->2.7.3.4
+  // 2-probability->2.7.3.4
 @misc{sutherland2021generativemodelsmodelcriticism,
-      title={Generative Models and Model Criticism via Optimized Maximum Mean Discrepancy}, 
-      author={Danica J. Sutherland and Hsiao-Yu Tung and Heiko Strathmann and Soumyajit De and Aaditya Ramdas and Alex Smola and Arthur Gretton},
-      year={2021},
-      eprint={1611.04488},
-      archivePrefix={arXiv},
-      primaryClass={stat.ML},
-      url={https://arxiv.org/abs/1611.04488}, 
+  title={Generative Models and Model Criticism via Optimized Maximum Mean Discrepancy}, 
+  author={Danica J. Sutherland and Hsiao-Yu Tung and Heiko Strathmann and Soumyajit De and Aaditya Ramdas and Alex Smola and Arthur Gretton},
+  year={2021},
+  eprint={1611.04488},
+  archivePrefix={arXiv},
+  primaryClass={stat.ML},
+  url={https://arxiv.org/abs/1611.04488}, 
 }
 
-// 2-Probability->2.7.3.4
+  // 2-probability->2.7.3.4
 @misc{flaxman2016bayesianlearningkernelembeddings,
-      title={Bayesian Learning of Kernel Embeddings}, 
-      author={Seth Flaxman and Dino Sejdinovic and John P. Cunningham and Sarah Filippi},
-      year={2016},
-      eprint={1603.02160},
-      archivePrefix={arXiv},
-      primaryClass={stat.ML},
-      url={https://arxiv.org/abs/1603.02160}, 
+  title={Bayesian Learning of Kernel Embeddings}, 
+  author={Seth Flaxman and Dino Sejdinovic and John P. Cunningham and Sarah Filippi},
+  year={2016},
+  eprint={1603.02160},
+  archivePrefix={arXiv},
+  primaryClass={stat.ML},
+  url={https://arxiv.org/abs/1603.02160}, 
 }
 
-// 3-statistics->3.2.4
+  // 3-statistics->3.2.4
 @misc{martin2020computingbayesbayesiancomputation,
-      title={Computing Bayes: Bayesian Computation from 1763 to the 21st Century}, 
-      author={Gael M. Martin and David T. Frazier and Christian P. Robert},
-      year={2020},
-      eprint={2004.06425},
-      archivePrefix={arXiv},
-      primaryClass={stat.CO},
-      url={https://arxiv.org/abs/2004.06425}, 
+  title={Computing Bayes: Bayesian Computation from 1763 to the 21st Century}, 
+  author={Gael M. Martin and David T. Frazier and Christian P. Robert},
+  year={2020},
+  eprint={2004.06425},
+  archivePrefix={arXiv},
+  primaryClass={stat.CO},
+  url={https://arxiv.org/abs/2004.06425}, 
 }
 
-// 3-statistics->3.3.2
+  // 3-statistics->3.3.2
 @book{efron1994introduction,
   title={An introduction to the bootstrap},
   author={Efron, Bradley and Tibshirani, Robert J},
   year={1993},
   publisher={Chapman and Hall/CRC},
-  % doi={10.1201/9780429246593},
+  doi={10.1201/9780429246593},
   url={https://www.hms.harvard.edu/bss/neuro/bornlab/nb204/statistics/bootstrap.pdf}
 }
 
-// 3-statistics->3.3.6
+  // 3-statistics->3.3.6
 @article{efron01021986,
-author = {B. Efron},
-title = {Why Isn't Everyone a Bayesian?},
-journal = {The American Statistician},
-volume = {40},
-number = {1},
-pages = {1--5},
-year = {1986},
-publisher = {ASA Website},
-% doi = {10.1080/00031305.1986.10475342},
-% url = {https://www.tandfonline.com/doi/abs/10.1080/00031305.1986.10475342},
-url={https://www2.isye.gatech.edu/isyebayes/bank/efronwhy1986.pdf},
-eprint = {https://www.tandfonline.com/doi/pdf/10.1080/00031305.1986.10475342}
+  author = {B. Efron},
+  title = {Why Isn't Everyone a Bayesian?},
+  journal = {The American Statistician},
+  volume = {40},
+  number = {1},
+  pages = {1--5},
+  year = {1986},
+  publisher = {ASA Website},
+  doi={10.1080/00031305.1986.10475342},
+  url={https://www2.isye.gatech.edu/isyebayes/bank/efronwhy1986.pdf},
 }
 
-// 3-statistics->3.5.2.3
+  // 3-statistics->3.5.2.3
 @article{kasswasserman1996,
   author={Robert E. Kass and Larry Wasserman},
   title={The Selection of Prior Distributions by Formal Rules},
@@ -142,11 +140,11 @@ eprint = {https://www.tandfonline.com/doi/pdf/10.1080/00031305.1986.10475342}
   number={435},
   pages={1343--1370},
   year={1996},
-  % doi={10.2307/2291752},
+  doi={10.2307/2291752},
   url={https://www.stat.cmu.edu/~kass/papers/rules.pdf}
 }
 
-// 3-statistics->3.5.3.3
+  // 3-statistics->3.5.3.3
 @book{robert2007bayesian,
   author={Christian P. Robert},
   title={The Bayesian Choice: From Decision-Theoretic Foundations to Computational Implementation},
@@ -154,11 +152,11 @@ eprint = {https://www.tandfonline.com/doi/pdf/10.1080/00031305.1986.10475342}
   year={2007},
   edition={2nd},
   isbn={9780387719605},
-  % doi={10.1007/0-387-71599-1},
+  doi={10.1007/0-387-71599-1},
   url={https://link.springer.com/book/10.1007/0-387-71599-1}
 }
 
-// 3-statistics->3.5.3.3
+  // 3-statistics->3.5.3.3
 @inproceedings{pmlrnalisnick18a,
   title={Learning Priors for Invariance},
   author={Nalisnick, Eric and Smyth, Padhraic},
@@ -170,11 +168,10 @@ eprint = {https://www.tandfonline.com/doi/pdf/10.1080/00031305.1986.10475342}
   series={Proceedings of Machine Learning Research},
   month={09--11 Apr},
   publisher={PMLR},
-  pdf={http://proceedings.mlr.press/v84/nalisnick18a/nalisnick18a.pdf},
   url={https://proceedings.mlr.press/v84/nalisnick18a.html},
 }
 
-// 3-statistics->3.5.6; 3.6.1; 3.6.2.1
+  // 3-statistics->3.5.6; 3.6.1; 3.6.2.1
 @book{gelman2013bayesian,
   author={Andrew Gelman and John B. Carlin and Hal S. Stern and David B. Dunson and Aki Vehtari and Donald B. Rubin},
   title={Bayesian Data Analysis},
@@ -182,11 +179,11 @@ eprint = {https://www.tandfonline.com/doi/pdf/10.1080/00031305.1986.10475342}
   publisher={Chapman and Hall/CRC},
   year={2014},
   isbn={9781439840955},
-  %doi={10.1201/b16018},
+  doi={10.1201/b16018},
   url={http://www.stat.columbia.edu/~gelman/book/}
 }
 
-// 3-statistics->3.7.3
+  // 3-statistics->3.7.3
 @misc{chen1996empiricalstudysmoothingtechniques,
   title={An Empirical Study of Smoothing Techniques for Language Modeling}, 
   author={Stanley F. Chen and Joshua T. Goodman},
@@ -197,11 +194,11 @@ eprint = {https://www.tandfonline.com/doi/pdf/10.1080/00031305.1986.10475342}
   url={https://arxiv.org/abs/cmp-lg/9606011}, 
 }
 
-// 3-statistics->3.7.3
+  // 3-statistics->3.7.3
 @article{mackay_peto_1995,
   title={A hierarchical Dirichlet language model},
   volume={1},
-  % DOI={10.1017/S1351324900000218},
+  doi={10.1017/S1351324900000218},
   number={3},
   journal={Natural Language Engineering},
   author={MacKay, David J. C. and Peto, Linda C. Bauman},
@@ -210,14 +207,13 @@ eprint = {https://www.tandfonline.com/doi/pdf/10.1080/00031305.1986.10475342}
   url={https://www.cs.toronto.edu/pub/gh/MacKay+Peto-1995.pdf}
 }
 
-// 3-statistics->3.8.3.3
+  // 3-statistics->3.8.3.3
 @article{ashton_2022,
   title={Nested sampling for physical scientists},
   volume={2},
   ISSN={2662-8449},
-  url={https://arxiv.org/abs/2205.15570},
-  % url={http://dx.doi.org/10.1038/s43586-022-00121-x},
-  % DOI={10.1038/s43586-022-00121-x},
+  url={https://arxiv.org/pdf/2205.15570},
+  doi={10.1038/s43586-022-00121-x},
   number={1},
   journal={Nature Reviews Methods Primers},
   publisher={Springer Science and Business Media LLC},
@@ -226,7 +222,7 @@ eprint = {https://www.tandfonline.com/doi/pdf/10.1080/00031305.1986.10475342}
   month={may}
 }
 
-// 3-statistics->3.8.5
+  // 3-statistics->3.8.5
 @InProceedings{pmlrlotfi22a,
   title={{B}ayesian Model Selection, the Marginal Likelihood, and Generalization},
   author={Lotfi, Sanae and Izmailov, Pavel and Benton, Gregory and Goldblum, Micah and Wilson, Andrew Gordon},
@@ -238,11 +234,10 @@ eprint = {https://www.tandfonline.com/doi/pdf/10.1080/00031305.1986.10475342}
   series={Proceedings of Machine Learning Research},
   month={17--23 Jul},
   publisher={PMLR},
-  pdf={https://proceedings.mlr.press/v162/lotfi22a/lotfi22a.pdf},
   url={https://proceedings.mlr.press/v162/lotfi22a.html},
 }
 
-// 3-statistics->3.8.7
+  // 3-statistics->3.8.7
 @misc{gelman2013understandingpredictiveinformationcriteria,
   title={Understanding predictive information criteria for Bayesian models}, 
   author={Andrew Gelman and Jessica Hwang and Aki Vehtari},
@@ -253,18 +248,165 @@ eprint = {https://www.tandfonline.com/doi/pdf/10.1080/00031305.1986.10475342}
   url={https://arxiv.org/abs/1307.5928}, 
 }
 
-// test1
-@misc{zhao2018sensitivityanalysisinverseprobability,
-      title={Sensitivity analysis for inverse probability weighting estimators via the percentile bootstrap}, 
-      author={Qingyuan Zhao and Dylan S. Small and Bhaswar B. Bhattacharya},
-      year={2018},
-      eprint={1711.11286},
-      archivePrefix={arXiv},
-      primaryClass={stat.ME},
-      url={https://arxiv.org/abs/1711.11286}, 
+  // 04-graphical-models->4.2.7.5
+@article{baldi1994smooth,
+  author={Baldi, Pierre and Chauvin, Yves},
+  title={Smooth On-Line Learning Algorithms for Hidden Markov Models},
+  journal={Neural Computation},
+  volume={6},
+  number={2},
+  pages={307-318},
+  year={1994},
+  month={03},
+  issn={0899-7667},
+  doi={10.1162/neco.1994.6.2.307},
+  url={https://direct.mit.edu/neco/article-pdf/6/2/307/812736/neco.1994.6.2.307.pdf},
 }
 
-// test2
+  // 04-graphical-models->4.2.7.5
+@article{lauritzen1995algorithm,
+  title={The EM algorithm for graphical association models with missing data},
+  author={Lauritzen, Steffen L},
+  journal={Computational statistics \& data analysis},
+  volume={19},
+  number={2},
+  pages={191--201},
+  year={1995},
+  publisher={Elsevier},
+  doi={10.1016/0167-9473(93)E0056-A},
+  url={https://www.stats.ox.ac.uk/~steffen/papers/em95.pdf}
+}
+
+  // 04-graphical-models->4.3.2.1
+@book{georgii2011,
+  url={https://doi.org/10.1515/9783110250329},
+  title={Gibbs Measures and Phase Transitions},
+  author={Hans-Otto Georgii},
+  publisher={De Gruyter},
+  address={Berlin, New York},
+  doi={10.1515/9783110250329},
+  isbn={9783110250329},
+  year={2011},
+  lastchecked={2025-09-20}
+}
+
+  // 04-graphical-models->4.3.2.2
+@article{matveev1995,
+  title={Complex-temperature singularities of the susceptibility in the D=2 Ising model. I. Square lattice},
+  volume={28},
+  ISSN={1361-6447},
+  url={https://arxiv.org/pdf/hep-lat/9408020},
+  DOI={10.1088/0305-4470/28/6/012},
+  number={6},
+  journal={Journal of Physics A: Mathematical and General},
+  publisher={IOP Publishing},
+  author={Matveev, V and Shrock, R},
+  year={1995},
+  month=mar, 
+  pages={1557–1583} 
+}
+
+  // 04-graphical-models->4.3.3.3
+@InProceedings{pmlrsalakhutdinov09a,
+  title={Deep Boltzmann Machines},
+  author={Salakhutdinov, Ruslan and Hinton, Geoffrey},
+  booktitle={Proceedings of the Twelfth International Conference on Artificial Intelligence and Statistics},
+  pages={448--455},
+  year={2009},
+  editor={van Dyk, David and Welling, Max},
+  volume={5},
+  series={Proceedings of Machine Learning Research},
+  address={Hilton Clearwater Beach Resort, Clearwater Beach, Florida USA},
+  month={16--18 Apr},
+  publisher={PMLR},
+  pdf={http://proceedings.mlr.press/v5/salakhutdinov09a/salakhutdinov09a.pdf},
+  url={https://proceedings.mlr.press/v5/salakhutdinov09a.html},
+}
+
+  // 04-graphical-models->4.3.5
+@book{rue2005gaussian,
+  title={Gaussian Markov random fields: theory and applications},
+  author={Rue, Havard and Held, Leonhard},
+  year={2005},
+  publisher={Chapman and Hall/CRC},
+  doi={10.1201/9780203492024}
+}
+
+  // 04-graphical-models->4.3.5
+@misc{stoehr2017reviewstatisticalinferencemethods,
+  title={A review on statistical inference methods for discrete Markov random fields}, 
+  author={Julien Stoehr},
+  year={2017},
+  eprint={1704.03331},
+  archivePrefix={arXiv},
+  primaryClass={stat.ME},
+  url={https://arxiv.org/abs/1704.03331}, 
+}
+
+  // 04-graphical-models->4.4.2.1
+@misc{chen2017deeplabsemanticimagesegmentation,
+  title={DeepLab: Semantic Image Segmentation with Deep Convolutional Nets, Atrous Convolution, and Fully Connected CRFs}, 
+  author={Liang-Chieh Chen and George Papandreou and Iasonas Kokkinos and Kevin Murphy and Alan L. Yuille},
+  year={2017},
+  eprint={1606.00915},
+  archivePrefix={arXiv},
+  primaryClass={cs.CV},
+  url={https://arxiv.org/abs/1606.00915}, 
+}
+
+  // 04-graphical-models->4.4.4
+@inproceedings{nips2003_878d5691,
+  author={Taskar, Ben and Guestrin, Carlos and Koller, Daphne},
+  booktitle={Advances in Neural Information Processing Systems},
+  editor={S. Thrun and L. Saul and B. Sch\"{o}lkopf},
+  pages={},
+  publisher={MIT Press},
+  title={Max-Margin Markov Networks},
+  url={https://proceedings.neurips.cc/paper_files/paper/2003/file/878d5691c824ee2aaf770f7d36c151d6-Paper.pdf},
+  volume={16},
+  year={2003}
+}
+
+  // 04-graphical-models->4.4.4
+@article{jmlrtsochantaridis05a,
+  author={Ioannis Tsochantaridis and Thorsten Joachims and Thomas Hofmann and Yasemin Altun},
+  title={Large Margin Methods for Structured and Interdependent Output Variables},
+  journal={Journal of Machine Learning Research},
+  year={2005},
+  volume={6},
+  number={50},
+  pages={1453--1484},
+  url={http://jmlr.org/papers/v6/tsochantaridis05a.html}
+}
+  // 04-graphical-models->4.4.4
+
+@InProceedings{pmlrbelanger17a,
+  title={End-to-End Learning for Structured Prediction Energy Networks},
+  author={David Belanger and Bishan Yang and Andrew McCallum},
+  booktitle={Proceedings of the 34th International Conference on Machine Learning},
+  pages={429--439},
+  year={2017},
+  editor={Precup, Doina and Teh, Yee Whye},
+  volume={70},
+  series={Proceedings of Machine Learning Research},
+  month={06--11 Aug},
+  publisher={PMLR},
+  pdf={http://proceedings.mlr.press/v70/belanger17a/belanger17a.pdf},
+  url={https://proceedings.mlr.press/v70/belanger17a.html},
+}
+
+  // test1
+@misc{zhao2018sensitivityanalysisinverseprobability,
+  title={Sensitivity analysis for inverse probability weighting estimators via the percentile bootstrap}, 
+  author={Qingyuan Zhao and Dylan S. Small and Bhaswar B. Bhattacharya},
+  year={2018},
+  eprint={1711.11286},
+  archivePrefix={arXiv},
+  primaryClass={stat.ME},
+  url={https://arxiv.org/abs/1711.11286}, 
+}
+
+  // test2
 @article{zhang1998characterization,
   title={On characterization of entropy function via information inequalities},
   author={Zhang, Zhen and Yeung, Raymond W},

--- a/content/learning/probml/04-graphical-models.md
+++ b/content/learning/probml/04-graphical-models.md
@@ -168,17 +168,19 @@ date: 2025-08-13
         
         
 #### 4.2.7.5 Using EM to fit CPTs in the incomplete data case
-- The Expectation-Maximization (EM) [[Lau95](https://www.sciencedirect.com/science/article/pii/0167947393E0056A)] algorithm is an iterative approach for MLE in the presence of latent variables (in depth - Sec.6.5.3)
+- The Expectation-Maximization (EM) @lauritzen1995algorithm algorithm is an iterative approach for MLE in the presence of latent variables (in depth - Sec.6.5.3)
 - Consists of two main steps: E-step and the M-step
     - 1) Initialize the parameters of the model, including any latent variables.
     - 2) E-step: Estimate the expected value of the latent variables $\boldsymbol{z}_n$ given the observed data and the current parameter estimates $\Rightarrow$ rather than returning the full posterior we return **Estimated Sufficient Stats (ESS)**
     - 3) M-step: Maximize the likelihood of the observed data by updating the parameter estimates based on the ESS/expected values of the latent variables obtained in the E-step
     - 4) Repeat steps 2 and 3 until convergence is achieved, i.e., the change in the parameter estimates is below a certain threshold or the log-likelihood of the observed data no longer increases.
-- See book for EM example based on Sec.4.2.7.2
+- See book for EM example based on Sec.4.2.7.2 
+
+- test citation baldi @baldi1994smooth
 
 
 #### 4.2.7.6 Using SGD to fit CPTs in the incomplete data case
-- In the same scenario as above (Sec.4.6.7.5). **Stochastic Gradient Descent (SGD)** [[BC94](https://watermark.silverchair.com/neco.1994.6.2.307.pdf?token=AQECAHi208BE49Ooan9kkhW_Ercy7Dm3ZL_9Cf3qfKAc485ysgAAA18wggNbBgkqhkiG9w0BBwagggNMMIIDSAIBADCCA0EGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMXaZxZitVAOclrvUfAgEQgIIDEnK7d6u82QVYgd6ENpHqmBFZhb1ciIj1YnXsRBw8F1t3d2_KfX0sPAC-ObCkxiJE9C4mIEOjQ0jRHSEif7GEr7zE2Yqjq0f7JxWs_U0hC328rV1m8mK1TEwf1HKVzJ70LaFHBGMtkIEHDZd1YlCjLIMHqtmYGgDtvdVq0MJCqC8CmisaE5W6urmlHuv1OpSRzsLIDrvlGc3pROfbTalXT_tMrC3uWeyD_9Ksrdc8mfZ549eB5YdEx4zE8rq8OkWIBF7_hFvsIVCE2xsR3j2CKvG3-tP-nRLCLJ_ipxuOyyZ5DXEGFWkDLsEanNkNrllFi5nztgcIGu6icTeMoZR3BZpjq_OobaxMTY_jKKuWX2u3n46MfMKVpy0pJKgVmavZIZXrmm-tPaNkDcu13PGs7UurjcP_cskflad-tnWeLtJEObrnYQUFrIOE8lSCNrIuumNwKz_wm5RGbx6luWmnh6AF9oYGt7XScLiYP0uVFgFkwGPczIGT7qZsp_YUwFCCSQwR3PaYwfMZJcem6KdgACSt5cuFqh_NrlMV5eprpWzNrphJgp4ThuPPRiEIEB_lyntDw915jtKeQ1U30ZRXDb31TwZc1ZcuFeZHwMAowegX8Z0Hd6UPkTflYsR1OIelgwpv0upwN-59r2p_E9libMJZVFaKkusgOCeyOQBs1gcEYkdZE3VL1fU4LwVpcWDcf3MWe0cZM0KxK_QIZUeqdnRLWP2jWokIUkk7jyN3I48-raYOqI4G96OV3qvHP59oKEidrTHqBM0dAzB1IEKN1k5xXqrnrsCc5Us8fGWm8K8Up01gwwThczZSYHYFSV2KWr47QaxdL2wRllhQp54lbJ7Kq3QAoh31j_DGViejfb15S4j3d5YemUhIY7_lrvitBgEXgiQ4OoHt5wprFoT8SbLwILl9YNxvFWrC4souicxPRNfYNaXjmUYjpkfUmi35P5Vkb8_qoQHCkoyaCZNaavpKg8UDqI8tna7vPcU56aeXRucev5U1mXHWpDyMFeSOK1kKiV77yxAVlsAyEu5RGwy7nw); [Bin+97](https://link.springer.com/content/pdf/10.1023/A:1007421730016.pdf)] instead of EM is more common because is a scalable batch algorithm
+- In the same scenario as above (Sec.4.6.7.5). **Stochastic Gradient Descent (SGD)** @, @ instead of EM is more common because is a scalable batch algorithm
 - The steps are:
     - *Collapse* the model by MARGINALIZING OUT $\boldsymbol{z}_{n}$ from the marginal likelihood for each $n$-th node-observation $\boldsymbol{x}_{n}$ as: $p(\boldsymbol{x}_{n}\mid\boldsymbol{\theta})=\sum_{\boldsymbol{z}_{n}}p(\boldsymbol{z}_{n}\mid\boldsymbol{\theta}_{z})p(\boldsymbol{x}_{n}\mid\boldsymbol{z}_{n},\boldsymbol{\theta}_{x})$
     - the log-likelihood is: $\log{p(\mathcal{D}\mid\boldsymbol{\theta})}=l(\boldsymbol{\theta})=\sum_{n=1}^{N}\log{p\left(\boldsymbol{x}_{n}\mid\boldsymbol{\theta}\right)}$
@@ -218,7 +220,9 @@ date: 2025-08-13
 - Assuming a joint distribution that satisfies the CI properties for UPGMs (will be defined in Sec 4.3.6) then the **Hammersley-Clifford** theorem is:
     - $p(\boldsymbol{x}\mid\boldsymbol{\theta})=\frac{1}{Z(\boldsymbol{\theta}_{c})}\prod_{c\in\mathcal{C}}\psi_{c}(\boldsymbol{x}_{c};\boldsymbol{\theta}_{c})$
     - where the partition function $Z(\boldsymbol{\theta})=\sum_{\boldsymbol{x}}\prod_{c\in\mathcal{C}}\psi_{c}(\boldsymbol{x}_{c};\boldsymbol{\theta}_{c})$ normalizes the dist to 1
-    - `cool fact.- part func is Z because of 'Zustandssumme' which means 'sum over states' pretty literal as expected comming from a German brain`
+    - > [!info] Cool fact
+      > 
+      > The partition function uses the symbol $Z$ because of *'Zustandssumme'* which means *'sum over states'* pretty literal as expected comming from a German brain
 
 
 #### 4.3.1.2 Gibbs distribution
@@ -242,7 +246,7 @@ date: 2025-08-13
         - with: $\mathcal{E}(\boldsymbol{x};J)=-J\sum_{i\sim j}x_{i}x_{j}$, where the pair $x_{i}x_{j}$ is $-1$ ($+1$) when $x_i=x_j$ ($x_i\neq x_j$) 
         - moreover, if all contributions are $+J>0$ ($-J<0$) in ML this is known as an **associative Markov network** in Physics **ferromagnet** (**antiferromagnet/frustrated system** $\Rightarrow$ neighbors can't be in same spin/state thus system has many solutions)
 - if we study an approx infinite lattice we see that there is a *critical* temperature for which clusters will form, this emerges alongside larger values of $J\geq J_{c}$ 
-    - isotropic case has shown [[Geo88](https://books.google.ca/books?hl=en&lr=&id=3vMCnvMH-hkC&oi=fnd&pg=PR7&dq=gibbs+measures+and+phase+transitions+1988&ots=kzJfPJNbQv&sig=USObALiUs8W-96YGKcikldzot28&redir_esc=y#v=onepage&q=gibbs%20measures%20and%20phase%20transitions%201988&f=false)]: $J_{c}=\frac{1}{2}\log{(1+\sqrt{2})}\approx 0.44$
+    - isotropic case @georgii2011 has shown: $J_{c}=\frac{1}{2}\log{(1+\sqrt{2})}\approx 0.44$
 - More complete model introduces external fields (acting on unary terms $\psi_i(x_i)$) which result in: $p(\boldsymbol{x}\mid\boldsymbol{\theta})=\frac{1}{Z(\boldsymbol{\theta})}\prod_{i}\psi(x_i;\boldsymbol{\theta})\prod_{i\sim j}\psi(x_i,x_j;\boldsymbol{\theta})$ where $\psi_{i}(x_i)=\begin{cases}e^{\alpha} & \text { if } x_i=+1 \\ e^{-\alpha} & \text { if } x_i=-1 \end{cases}$
     - written as an energy model: $\mathcal{E}(\boldsymbol{x}\mid\boldsymbol{\theta})=-\alpha\sum_{i}x_i -J\sum_{i\sim j}x_ix_j$
         
@@ -252,7 +256,7 @@ date: 2025-08-13
 - Potts is the special case when same-neigbor-states contribute same magnitude $J$ such that: $\psi_{ij}(x_i=k,x_j=k^{\prime})=\begin{cases}e^{J} & \text { if } k=k^{\prime} \\ e^{0} & \text { if } k \neq k^{\prime}\end{cases}$
     - Meaing that when $J>0$ neighboors are encouraged to have the same label (thus the name *Markov associative* model)
     - when Potts $J_{\text{potts}}=2J_{\text{ising}}$ model reduces to Ising
-    - phase transistion (in Potts 2D) occurs at [[MS96](https://iopscience.iop.org/article/10.1088/0305-4470/28/6/012/meta?casa_token=GPFPgd26oiEAAAAA:uBLoJ2B8zfCTgrzp_OzQrULGPC1pZKTDBCDKP0f7-XWZ7_dZgGL43lTNbBiFvyvKmOp8fPp6smf92MeMteGZQOWxbpg)]: $J_c=\log{(1+\sqrt{K})}$
+    - phase transistion (in Potts 2D @matveev1995 ) occurs at: $J_c=\log{(1+\sqrt{K})}$
 - More general formulation, adding an external field, the energy model is: $\mathcal{E}(\boldsymbol{x}\mid\boldsymbol{\theta})=-\sum_{i}\sum_{k=1}^{K}\alpha_{k}\mathbb{I}(x_i=k)-J\sum_{i\sim j}\mathbb{I}(x_i=x_j)$
 
 #### 4.3.2.3 Potts models for protein structure prediction
@@ -287,7 +291,7 @@ date: 2025-08-13
 
 
 ### 4.3.3.3 Deep Boltzmann Machines
-- Achieved by stacking multiple RBMs [[SH09](https://proceedings.mlr.press/v5/salakhutdinov09a)] eg. a two layer RBM would be: $p(\boldsymbol{x},\boldsymbol{z}_1,\boldsymbol{z}_2\mid\boldsymbol{\theta})=\frac{1}{\mathbf{Z}(\mathbf{W}_1,\mathbf{W}_2)}\exp{(\boldsymbol{x}^{\top}\mathbf{W}_1\boldsymbol{z}_1+\boldsymbol{z}_1^{\top}\mathbf{W}_2\boldsymbol{z}_2)}$
+- Achieved by stacking multiple RBMs @pmlrsalakhutdinov09a eg. a two layer RBM would be: $p(\boldsymbol{x},\boldsymbol{z}_1,\boldsymbol{z}_2\mid\boldsymbol{\theta})=\frac{1}{\mathbf{Z}(\mathbf{W}_1,\mathbf{W}_2)}\exp{(\boldsymbol{x}^{\top}\mathbf{W}_1\boldsymbol{z}_1+\boldsymbol{z}_1^{\top}\mathbf{W}_2\boldsymbol{z}_2)}$
     - dropped the bias terms for brevity
     - see Fig.4.22(a) for visual picture. Note that Deep Boltzmann machines are UPGMs whereas Deep belief nets are DPGMs
     
@@ -322,7 +326,7 @@ date: 2025-08-13
         - Moreover, if we define a feature for every combination of words we then can represent ANY dist!
         
 ### 4.3.5 Gaussian MRFs
-- Sec.4.2.3 was about representing a MVN/Gaussian as a DPGM, now we represent it in an UPGM, see more [[RH05](https://books.google.com.bo/books?hl=en&lr=&id=TLBYs-faw-0C&oi=fnd&pg=PP1&dq=gaussian+markov+random+fields+theory+and+application&ots=RO2RuKTtmW&sig=OIrHNCiogY5tCJe0NFKNXzCcevs&redir_esc=y#v=onepage&q=gaussian%20markov%20random%20fields%20theory%20and%20application&f=false)].
+- Sec.4.2.3 was about representing a MVN/Gaussian as a DPGM, now we represent it in an UPGM, see more in @rue2005gaussian.
 
 
 #### 4.3.5.1 Standard GMRFs
@@ -392,7 +396,7 @@ date: 2025-08-13
     - $$\nabla_{\boldsymbol{\theta}}\log Z(\boldsymbol{\theta})=\frac{1}{Z(\boldsymbol{\theta})}\int \nabla_{\boldsymbol{\theta}}\tilde{p}(\boldsymbol{x};\boldsymbol{\theta})d\boldsymbol{x}=\mathbb{E}_{\boldsymbol{x}\sim p(\boldsymbol{x};\boldsymbol{\theta})}[\nabla_{\boldsymbol{\theta}}\log \tilde{p}(\boldsymbol{x};\boldsymbol{\theta})]$$
     - thus we need to draw samples at EACH step of the SGD training just to estimate the gradient
 - Future chapters discuss efficient sampling methods ie. *gradient-based MCMC* (Sec.24.2.1), and alternative estimators instead of MLE eg. *contrastive divergence* (Sec.24.2.2) & *maximum pseudo-likelihood estimation* (Sec.4.3.9.3) 
-    - see [[Sto17](https://arxiv.org/abs/1704.03331)] for a great review on param estimation in MRFs
+    - see @stoehr2017reviewstatisticalinferencemethods for a great review on param estimation in MRFs
     
 #### 4.3.9.3 Maximum pseudolikelihood estimation
 - An alternative to maximizing the likelihood we can maximize the *pseudo likelihood* - it predicts each node $x_d$ given all neighbors $\boldsymbol{x}_{-d}$. The objective is easier to compute because the full-conditional for each $d$-th node (and all $N$ datapoints) $p(x_d\mid\boldsymbol{x}_{-d},\boldsymbol{\theta})$ only sums over the states of such node
@@ -435,7 +439,7 @@ date: 2025-08-13
 #### 4.4.2.1 Semantic segmentation
 - Deals with the problem of identifying the label of every pixel in an image
     - CNNs aim to achieve this via softmax outputs per pixel/node but FAILS to capture long-range dependencies
-    - feeding the CNNs' output to *fully-connected CRFs* (grid CRFs doesn't improve capturing long-range dependencies) CRFsimproves segmentation [[Che+17a](https://ieeexplore.ieee.org/abstract/document/7913730?casa_token=gkAJa-qIWzsAAAAA:XiKRhsril5diX8e1aoKlGp0F9lVPGWPU9PdKShF3SAWpxQAVH1kOnm0Pyipy453nbiMfDb9JFGBS)]
+    - feeding the CNNs' output to *fully-connected CRFs* (grid CRFs doesn't improve capturing long-range dependencies) CRFsimproves segmentation @chen2017deeplabsemanticimagesegmentation
     - unfortunately, CRFs computation is intractable so
         - in the case of Gaussian potentials there are workarounds using *mean field algorithms*
         - mean field algos can be implemented using RNNs
@@ -470,7 +474,7 @@ date: 2025-08-13
     
 ### 4.4.4 Other cases  to structured prediction
 - Further notable approaches to structured prediction beyond CRFs are: *graph neural networks* (Sec.16.3.6) and sequence-to-sequence models like **transformers** (Sec.16.3.5)
-    - other historical notable mentions: *max margin Markov nets* [[TGK03](https://proceedings.neurips.cc/paper/2003/hash/878d5691c824ee2aaf770f7d36c151d6-Abstract.html)], *structural support vector machines* [[Tso+05](https://www.jmlr.org/papers/volume6/tsochantaridis05a/tsochantaridis05a.pdf)], *structured prediction energy models* [[BYM17](https://proceedings.mlr.press/v70/belanger17a.html)] (Chapter.24)
+    - other historical notable mentions: *max margin Markov nets* @nips2003_878d5691, *structural support vector machines* @jmlrtsochantaridis05a, *structured prediction energy models* @pmlrbelanger17a (Chapter.24)
 
 ## 4.5 Comparing directed and undirected graphical PGMs
 - There are different advantages to both, additionally these can sometimes be converted between both structures.
@@ -495,3 +499,5 @@ date: 2025-08-13
 
 ### 4.5.3 Conditional directed vs undirected PGMs and the label bias problem
 - eg. in some graph architectures UDPGMs are **globally normalized** (by $Z$) whereas DPGMs are **locally normalized** (each node's Conditional PDist is normalized). However, UPGMs trade-off comes in computation cost as oppsed to DPGMs which are easier to train be 
+
+# References

--- a/quartz/plugins/transformers/alphaCitations.ts
+++ b/quartz/plugins/transformers/alphaCitations.ts
@@ -88,7 +88,7 @@ class AlphaLabelGenerator {
       return [entry.title.substring(0, 3)]
     }
     
-    return [entry.id || 'Autar']
+    return [entry.id || 'UNK']
   }
 
   private extractYear(entry: any): number {
@@ -229,8 +229,7 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
     externalResources() {
       return {
         css: [{
-          content: 
-          `
+          content: `
             .alpha-citation {
               font-weight: 500;
               color: var(--primary-color, #2563eb);
@@ -277,6 +276,23 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
             .bibliography-url:active {
               transform: translateY(0);
               box-shadow: 0 1px 2px rgba(37, 99, 235, 0.1);
+            }
+            
+            .bibliography-emoji-link {
+              display: inline;
+              margin-left: 0.25rem;
+              text-decoration: none;
+              font-size: 1rem;
+              transition: all 0.15s ease-in-out;
+            }
+            
+            .bibliography-emoji-link:hover {
+              transform: scale(1.2);
+              text-decoration: none;
+            }
+            
+            .bibliography-emoji-link:active {
+              transform: scale(1.1);
             }
           `
         }]
@@ -384,13 +400,12 @@ function replaceBibliographyLabels(node: Element, alphaLabels: Map<string, strin
         
         node.children.unshift(labelElement, { type: 'text', value: ' ' })
         
-        // Convert existing URLs to hyperlinks if available
+        // NEW: Format author names and handle smart links in bibliography
         if (entry) {
-          convertUrlsToHyperlinks(node, entry)
+          formatAuthorNames(node)
+          removeExistingUrls(node, entry)
+          appendSmartLinks(node, entry)
         }
-        
-        // NEW: Format author names in bibliography
-        formatAuthorNames(node)
       }
     }
   }
@@ -413,78 +428,126 @@ function formatAuthorNames(node: Element) {
   })
 }
 
-function convertUrlsToHyperlinks(node: Element, entry: any) {
-  const url = extractUrl(entry)
+// NEW FUNCTION: Remove existing URLs from text (added by rehype-citation)
+function removeExistingUrls(node: Element, entry: any) {
+  // Get all possible URLs that might be in the text
+  const urlsToRemove = []
   
-  if (!url) return
+  if (entry.DOI || entry.doi) {
+    const doi = entry.DOI || entry.doi
+    urlsToRemove.push(`https://doi.org/${doi}`)
+  }
   
-  // Find all text nodes and replace URLs with hyperlinks
-  visit(node, 'text', (textNode: Text, index, parent) => {
-    if (!parent || typeof index !== 'number') return
+  if (entry.URL || entry.url) {
+    urlsToRemove.push(entry.URL || entry.url)
+  }
+  
+  if (entry.archivePrefix === 'arXiv' && entry.eprint) {
+    urlsToRemove.push(`https://arxiv.org/abs/${entry.eprint}`)
+  }
+  
+  if (entry.pdf) {
+    urlsToRemove.push(entry.pdf)
+  }
+  
+  // Remove these URLs from text nodes
+  visit(node, 'text', (textNode: Text) => {
+    let text = textNode.value
     
-    const text = textNode.value
-    
-    // Check if this text node contains the URL
-    if (text.includes(url)) {
-      // Split the text around the URL
-      const parts = text.split(url)
-      const newChildren = []
-      
-      for (let i = 0; i < parts.length; i++) {
-        // Add text part
-        if (parts[i]) {
-          newChildren.push({ type: 'text', value: parts[i] })
-        }
-        
-        // Add hyperlinked URL (except after the last part)
-        if (i < parts.length - 1) {
-          newChildren.push({
-            type: 'element',
-            tagName: 'a',
-            properties: {
-              href: url,
-              target: '_blank',
-              rel: 'noopener noreferrer',
-              className: ['bibliography-url']
-            },
-            children: [{ type: 'text', value: url }]
-          })
-        }
+    urlsToRemove.forEach(url => {
+      if (url && text.includes(url)) {
+        // Remove the URL and any surrounding whitespace
+        text = text.replace(new RegExp(`\\s*${escapeRegex(url)}\\s*`, 'g'), ' ')
+        text = text.replace(/\s+/g, ' ').trim() // Clean up extra spaces
       }
-      
-      // Replace the original text node with the new children
-      parent.children.splice(index, 1, ...newChildren)
-    }
+    })
+    
+    textNode.value = text
   })
 }
 
-function extractUrl(entry: any): string | null {
-  // Check for URL field first
-  if (entry.URL && typeof entry.URL === 'string') {
-    return entry.URL
+// Helper function to escape special regex characters
+function escapeRegex(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+// NEW FUNCTION: Generate smart links based on simplified hierarchy
+function generateSmartLinks(entry: any): { primary?: {url: string, text: string}, secondary?: {url: string, emoji: string} } {
+  const result: { primary?: {url: string, text: string}, secondary?: {url: string, emoji: string} } = {}
+  
+  // Extract standard BibTeX fields only
+  const doi = entry.DOI || entry.doi
+  const url = entry.URL || entry.url
+  const archivePrefix = entry.archivePrefix
+  const eprint = entry.eprint
+  
+  // Case 1: arXiv has highest priority for academic papers
+  if (archivePrefix === 'arXiv' && eprint) {
+    const arxivUrl = `https://arxiv.org/abs/${eprint}`
+    result.primary = { url: arxivUrl, text: arxivUrl }
+    
+    // Always add PDF link for arXiv (🖻 links to PDF version)
+    const arxivPdfUrl = `https://arxiv.org/pdf/${eprint}`
+    result.secondary = { url: arxivPdfUrl, emoji: '   ↪ 🖻' }
+  } 
+
+  // Case 2: DOI as primary (most permanent)
+  else if (doi) {
+    const doiUrl = `https://doi.org/${doi}`
+    result.primary = { url: doiUrl, text: doiUrl }
+    
+    // Check if URL contains DOI, if not add as secondary with 🖻
+    if (url && !url.includes(doi)) {
+      result.secondary = { url: url, emoji: '   ↪ 🖻' }
+    }
+  }
+
+  // Case 3: URL only (fallback)
+  else if (url && url.slice(-4) === '.pdf') {
+    result.secondary = { url: url, emoji: '   ↪ 🖻' }
+  }
+
+  else if (url && url.slice(-4) !== '.pdf') {
+    result.primary = { url: url, text: url }
   }
   
-  if (entry.url && typeof entry.url === 'string') {
-    return entry.url
+  return result
+}
+
+// NEW FUNCTION: Append smart links to bibliography entry
+function appendSmartLinks(node: Element, entry: any) {
+  const links = generateSmartLinks(entry)
+  
+  if (!links.primary && !links.secondary) return
+  
+  // Helper function to append a link
+  const appendLink = (linkData: {url: string, text?: string, emoji?: string}) => {
+    // Add space before link
+    node.children.push({ type: 'text', value: ' ' })
+    
+    // Create link element
+    const linkElement: Element = {
+      type: 'element',
+      tagName: 'a',
+      properties: {
+        href: linkData.url,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+        className: linkData.emoji ? ['bibliography-emoji-link'] : ['bibliography-url']
+      },
+      children: [{ type: 'text', value: linkData.emoji || linkData.text || linkData.url }]
+    }
+    
+    node.children.push(linkElement)
   }
   
-  // // Check for DOI and convert to URL
-  // if (entry.DOI && typeof entry.DOI === 'string') {
-  //   return `https://doi.org/${entry.DOI}`
-  // }
-  //
-  // if (entry.doi && typeof entry.doi === 'string') {
-  //   return `https://doi.org/${entry.doi}`
-  // }
-  
-  // Check for arXiv ID and convert to URL
-  if (entry.archivePrefix === 'arXiv' && entry.eprint) {
-    return `https://arxiv.org/abs/${entry.eprint}`
+  // Add primary link
+  if (links.primary) {
+    appendLink({ url: links.primary.url, text: links.primary.text })
   }
   
-  if (entry.eprint && typeof entry.eprint === 'string' && entry.eprint.match(/^\d{4}\.\d{4,5}$/)) {
-    return `https://arxiv.org/abs/${entry.eprint}`
+  // Add secondary link (with 🖻 emoji)
+  if (links.secondary) {
+    appendLink({ url: links.secondary.url, emoji: links.secondary.emoji })
   }
-  
-  return null
 }


### PR DESCRIPTION
Remove all PDF field handling and custom field parsing
Simplify generateSmartLinks() to only handle DOI, URL, archivePrefix, eprint
Use 🖻 emoji for two purposes:

Links to URL when DOI ≠ URL
Links to arXiv PDF when archivePrefix exists


Remove all the debug logging since we know the issue now
Clean up the redundancy detection logic

Expected Results:

Baldi & Chauvin: https://doi.org/10.1162/neco.1994.6.2.307 (no 🖻 since DOI is contained in URL)
Gelman book: https://doi.org/10.1201/b16018 🖻 (🖻 links to book website)
arXiv papers: https://arxiv.org/abs/1506.04725 🖻 (🖻 links to PDF)