### PR TITLE
Fixing formatting of references, WIP

### DIFF
--- a/content/learning/blockchain/02-cryptographic-primitives.md
+++ b/content/learning/blockchain/02-cryptographic-primitives.md
@@ -151,4 +151,3 @@ date: 2024-09-22
 
 - Check the seminal paper on cryptographic primitives [@rogawayshrimpton2004]
 
-# References

--- a/content/learning/blockchain/06-chain-virtues.md
+++ b/content/learning/blockchain/06-chain-virtues.md
@@ -81,4 +81,3 @@ date: 2024-11-13
 - The Chain Growth virtue was identified in a later paper: *Speed-Security Tradeoffs in Blockchain Protocols* [@kiayias2015speed] 
 - The Ledger virtues of *liveness* and *safety* have been adapted from older literature [@lamport1982byzantine] in the context of two problems: (1) The Byzantine Generals Problem and (2) The Byzantine Agreement Problem
 
-# References

--- a/content/learning/probml/02-probability.md
+++ b/content/learning/probml/02-probability.md
@@ -196,5 +196,3 @@ $D_{\mathcal{F}}(P, Q) \triangleq \sup _{f \in \mathcal{F}}\left|\mathbb{E}_{p(\
     - as $f-$divergence (eq.2.312)
     - as IPM (eq.2.316)
 
----
-# References

--- a/content/learning/probml/03-statistics.md
+++ b/content/learning/probml/03-statistics.md
@@ -595,6 +595,3 @@ Therefore $H_0$ is probably false
 - An alternative to cross-validation for model selection is to score models based on the negative log-likelihood (NLL) PLUS some criteria (represented as complexity terms $C(m)$): $\mathcal{L}(m)=-\log{p(\mathcal{D}\mid\hat{\boldsymbol{\theta}},m)}+C(m)$
     - see more [@gelman2013understandingpredictiveinformationcriteria]
 
----
-
-# References

--- a/content/learning/probml/04-graphical-models.md
+++ b/content/learning/probml/04-graphical-models.md
@@ -500,4 +500,3 @@ date: 2025-08-13
 ### 4.5.3 Conditional directed vs undirected PGMs and the label bias problem
 - eg. in some graph architectures UDPGMs are **globally normalized** (by $Z$) whereas DPGMs are **locally normalized** (each node's Conditional PDist is normalized). However, UPGMs trade-off comes in computation cost as oppsed to DPGMs which are easier to train be 
 
-# References

--- a/quartz/plugins/transformers/alphaCitations.ts
+++ b/quartz/plugins/transformers/alphaCitations.ts
@@ -361,49 +361,51 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
     externalResources() {
       return {
         css: [{
+          inline: true,
           content: `
             .alpha-citation {
               font-weight: 500;
               color: var(--primary-color, #2563eb);
               text-decoration: none;
             }
-            
+
             .alpha-citation:hover {
               text-decoration: underline;
             }
-            
+
             .alpha-label {
               font-weight: 600;
-              margin-right: 0.5rem;
+              margin-right: 1rem;          /* Increased from 0.5rem for better spacing */
               color: var(--text-color, #374151);
+              display: inline-block;        /* Ensures consistent spacing */
+              min-width: fit-content;       /* Prevents label from wrapping */
             }
-            
+
             .bibliography-section {
               margin-top: 2rem;
               padding-top: 1rem;
               border-top: 1px solid var(--border-color, #e2e8f0);
             }
-            
+
             .bibliography-entry {
-              margin-bottom: 1rem;
-              padding-left: 1rem;
-              text-indent: -1rem;
-              line-height: 1.5;
+              margin-bottom: 1.5rem;        /* Increased from 1rem for better separation */
+              padding-left: 2rem;           /* Increased from 1rem for better hanging indent */
+              text-indent: -2rem;           /* Adjusted to match padding-left */
+              line-height: 1.6;             /* Increased from 1.5 for better readability */
             }
-            
+
             .bibliography-url {
               color: var(--primary-color, #2563eb);
               text-decoration: underline;
               font-size: 0.875rem;
               font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
-              background-color: var(--bg-secondary, #f8fafc);
               padding: 0.125rem 0.375rem;
               border-radius: 0.25rem;
               border: 1px solid var(--border-color, #e2e8f0);
               transition: all 0.15s ease-in-out;
               word-break: break-all;
             }
-            
+
             .bibliography-url:hover {
               background-color: var(--primary-color, #2563eb);
               color: white;
@@ -411,12 +413,12 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
               transform: translateY(-1px);
               box-shadow: 0 2px 4px rgba(37, 99, 235, 0.2);
             }
-            
+
             .bibliography-url:active {
               transform: translateY(0);
               box-shadow: 0 1px 2px rgba(37, 99, 235, 0.1);
             }
-            
+
             .bibliography-emoji-link {
               display: inline;
               margin-left: 0.25rem;
@@ -424,12 +426,12 @@ export const AlphaCitation: QuartzTransformerPlugin<Partial<AlphaCitationOptions
               font-size: 1rem;
               transition: all 0.15s ease-in-out;
             }
-            
+
             .bibliography-emoji-link:hover {
               transform: scale(1.2);
               text-decoration: none;
             }
-            
+
             .bibliography-emoji-link:active {
               transform: scale(1.1);
             }


### PR DESCRIPTION
padding-left: 2rem moves all content 2rem from the left margin
text-indent: -2rem pulls the first line back 2rem, so it starts at the original margin
This creates proper alignment where citation handles start at the left margin, but wrapped text is nicely indented